### PR TITLE
Fixes for issues 6 thru 9 and increases mass storage device poll time to reduce CPU usage

### DIFF
--- a/Usb.Events/UsbEventWatcher.Linux.c
+++ b/Usb.Events/UsbEventWatcher.Linux.c
@@ -1,19 +1,22 @@
+#include <time.h>
+#include <errno.h>  
 #include <libudev.h>
 #include <mntent.h>
 #include <stdio.h>
 #include <string.h>
+#include <stdbool.h>
 
 typedef struct UsbDeviceData
 {
-    char DeviceName[255];
-    char DeviceSystemPath[255];
-    char Product[255];
-    char ProductDescription[255];
-    char ProductID[255];
-    char SerialNumber[255];
-    char Vendor[255];
-    char VendorDescription[255];
-    char VendorID[255];
+	char DeviceName[255];
+	char DeviceSystemPath[255];
+	char Product[255];
+	char ProductDescription[255];
+	char ProductID[255];
+	char SerialNumber[255];
+	char Vendor[255];
+	char VendorDescription[255];
+	char VendorID[255];
 } UsbDeviceData;
 
 UsbDeviceData usbDevice;
@@ -30,251 +33,280 @@ struct udev* g_udev;
 
 struct udev_device* GetChild(struct udev* udev, struct udev_device* parent, const char* subsystem, const char* devtype)
 {
-    struct udev_device* child = NULL;
-    struct udev_enumerate* enumerate = udev_enumerate_new(udev);
+	struct udev_device* child = NULL;
+	struct udev_enumerate* enumerate = udev_enumerate_new(udev);
 
-    udev_enumerate_add_match_parent(enumerate, parent);
-    udev_enumerate_add_match_subsystem(enumerate, subsystem);
-    udev_enumerate_scan_devices(enumerate);
+	udev_enumerate_add_match_parent(enumerate, parent);
+	udev_enumerate_add_match_subsystem(enumerate, subsystem);
+	udev_enumerate_scan_devices(enumerate);
 
-    struct udev_list_entry* devices = udev_enumerate_get_list_entry(enumerate);
-    struct udev_list_entry* entry;
+	for (struct udev_list_entry* entry = udev_enumerate_get_list_entry(enumerate);
+		entry != NULL;
+		entry = udev_list_entry_get_next(entry))
+	{
+		const char* path = udev_list_entry_get_name(entry);
+		child = udev_device_new_from_syspath(udev, path);
 
-    udev_list_entry_foreach(entry, devices)
-    {
-        const char* path = udev_list_entry_get_name(entry);
-        child = udev_device_new_from_syspath(udev, path);
+		if (child)
+		{
+			if ((!devtype)
+				|| (strcmp(udev_device_get_devtype(child), devtype) == 0))
+			{
+				break;
+			}
+		}
+	}
 
-        if(!devtype)
-            break;
+	udev_enumerate_unref(enumerate);
 
-        if (strcmp(udev_device_get_devtype(child), devtype) == 0)
-        {
-            break;
-        }
-    }
-
-    udev_enumerate_unref(enumerate);
-
-    return child;
+	return child;
 }
 
 char* FindMountPoint(const char* dev_node)
 {
-    struct mntent* mount_table_entry;
-    FILE* file;
-    char* mount_point = NULL;
+	struct mntent* mount_table_entry;
+	FILE* file;
+	char* mount_point = NULL;
 
-    if (dev_node == NULL)
-    {
-        return NULL;
-    }
+	if (dev_node == NULL)
+	{
+		return NULL;
+	}
 
-    file = setmntent("/proc/mounts", "r");
+	file = setmntent("/proc/mounts", "r");
 
-    if (file == NULL)
-    {
-        return NULL;
-    }
+	if (file == NULL)
+	{
+		return NULL;
+	}
 
-    while (NULL != (mount_table_entry = getmntent(file)))
-    {
-        if (strncmp(mount_table_entry->mnt_fsname, dev_node, strlen(mount_table_entry->mnt_fsname)) == 0)
-        {
-            mount_point = mount_table_entry->mnt_dir;
+	while (NULL != (mount_table_entry = getmntent(file)))
+	{
+		if (strncmp(mount_table_entry->mnt_fsname, dev_node, strlen(mount_table_entry->mnt_fsname)) == 0)
+		{
+			mount_point = mount_table_entry->mnt_dir;
 
-            break;
-        }
-    }
+			break;
+		}
+	}
 
-    endmntent(file);
+	endmntent(file);
 
-    return mount_point;
+	return mount_point;
 }
 
 void GetDeviceInfo(struct udev* udev, struct udev_device* dev)
 {
-    const char* action = udev_device_get_action(dev);
-    if (! action)
-        action = "exists";
+	const char* action = udev_device_get_action(dev);
+	bool added = true;
 
-    int added = strcmp(action, "add") == 0;
+	if (action)
+	{
+		added = (strcmp(action, "remove") != 0);
+	}
 
-    int removed = strcmp(action, "remove") == 0;
+	usbDevice = empty;
 
-    if (added || removed)
-    {
-        usbDevice = empty;
-        
-        const char* DeviceName = udev_device_get_property_value(dev, "DEVNAME");
-        if (DeviceName)
-            strcpy(usbDevice.DeviceName, DeviceName);
+	const char* DeviceName = udev_device_get_property_value(dev, "DEVNAME");
+	if (DeviceName)
+		strcpy(usbDevice.DeviceName, DeviceName);
 
-        const char* DeviceSystemPath = udev_device_get_syspath(dev); //udev_device_get_property_value(dev, "DEVPATH");
-        if (DeviceSystemPath)
-            strcpy(usbDevice.DeviceSystemPath, DeviceSystemPath);
+	const char* DeviceSystemPath = udev_device_get_syspath(dev); //udev_device_get_property_value(dev, "DEVPATH");
+	if (DeviceSystemPath)
+		strcpy(usbDevice.DeviceSystemPath, DeviceSystemPath);
 
-        const char* Product = udev_device_get_property_value(dev, "ID_MODEL");
-        if (Product)
-            strcpy(usbDevice.Product, Product);
+	const char* Product = udev_device_get_property_value(dev, "ID_MODEL");
+	if (Product)
+		strcpy(usbDevice.Product, Product);
 
-        const char* ProductDescription = udev_device_get_property_value(dev, "ID_MODEL_FROM_DATABASE");
-        if (ProductDescription)
-            strcpy(usbDevice.ProductDescription, ProductDescription);
+	const char* ProductDescription = udev_device_get_property_value(dev, "ID_MODEL_FROM_DATABASE");
+	if (ProductDescription)
+		strcpy(usbDevice.ProductDescription, ProductDescription);
 
-        const char* ProductID = udev_device_get_property_value(dev, "ID_MODEL_ID");
-        if (ProductID)
-            strcpy(usbDevice.ProductID, ProductID);
+	const char* ProductID = udev_device_get_property_value(dev, "ID_MODEL_ID");
+	if (ProductID)
+		strcpy(usbDevice.ProductID, ProductID);
 
-        const char* SerialNumber = udev_device_get_property_value(dev, "ID_SERIAL_SHORT");
-        if (SerialNumber)
-            strcpy(usbDevice.SerialNumber, SerialNumber);
+	const char* SerialNumber = udev_device_get_property_value(dev, "ID_SERIAL_SHORT");
+	if (SerialNumber)
+		strcpy(usbDevice.SerialNumber, SerialNumber);
 
-        const char* Vendor = udev_device_get_property_value(dev, "ID_VENDOR");
-        if (Vendor)
-            strcpy(usbDevice.Vendor, Vendor);
+	const char* Vendor = udev_device_get_property_value(dev, "ID_VENDOR");
+	if (Vendor)
+		strcpy(usbDevice.Vendor, Vendor);
 
-        const char* VendorDescription = udev_device_get_property_value(dev, "ID_VENDOR_FROM_DATABASE");
-        if (VendorDescription)
-            strcpy(usbDevice.VendorDescription, VendorDescription);
+	const char* VendorDescription = udev_device_get_property_value(dev, "ID_VENDOR_FROM_DATABASE");
+	if (VendorDescription)
+		strcpy(usbDevice.VendorDescription, VendorDescription);
 
-        const char* VendorID = udev_device_get_property_value(dev, "ID_VENDOR_ID");
-        if (VendorID)
-            strcpy(usbDevice.VendorID, VendorID);
+	const char* VendorID = udev_device_get_property_value(dev, "ID_VENDOR_ID");
+	if (VendorID)
+		strcpy(usbDevice.VendorID, VendorID);
 
-        if (added)
-        {
-            InsertedCallback(usbDevice);
-        }
-
-        if (removed)
-        {
-            RemovedCallback(usbDevice);
-        }
-    }
+	if (added)
+	{
+		InsertedCallback(usbDevice);
+	}
+	else
+	{
+		RemovedCallback(usbDevice);
+	}
 }
 
 void ProcessDevice(struct udev* udev, struct udev_device* dev)
 {
-    if (dev)
-    {
-        if (udev_device_get_devnode(dev))
-        {
-            GetDeviceInfo(udev, dev);
-        }
+	if (dev)
+	{
+		if (udev_device_get_devnode(dev))
+		{
+			GetDeviceInfo(udev, dev);
+		}
 
-        udev_device_unref(dev);
-    }
+		udev_device_unref(dev);
+	}
 }
 
-void EnumerateDevices(struct udev* udev)
+void EnumerateDevices(struct udev* udev, const char* subsystem)
 {
-    struct udev_enumerate* enumerate = udev_enumerate_new(udev);
+	struct udev_enumerate* enumerate = udev_enumerate_new(udev);
 
-    udev_enumerate_add_match_subsystem(enumerate, "usb");
-    udev_enumerate_scan_devices(enumerate);
+	udev_enumerate_add_match_subsystem(enumerate, subsystem);
+	udev_enumerate_scan_devices(enumerate);
 
-    struct udev_list_entry* devices = udev_enumerate_get_list_entry(enumerate);
-    struct udev_list_entry* entry;
+	for (struct udev_list_entry* entry = udev_enumerate_get_list_entry(enumerate);
+		entry != NULL;
+		entry = udev_list_entry_get_next(entry))
+	{
+		const char* path = udev_list_entry_get_name(entry);
+		if (path)
+		{
+			struct udev_device* dev = udev_device_new_from_syspath(udev, path);
 
-    udev_list_entry_foreach(entry, devices)
-    {
-        const char* path = udev_list_entry_get_name(entry);
-        struct udev_device* dev = udev_device_new_from_syspath(udev, path);
+			if (dev)
+			{
+				ProcessDevice(udev, dev);
+			}
+		}
+	}
 
-        ProcessDevice(udev, dev);
-    }
+	udev_enumerate_unref(enumerate);
+}  
 
-    udev_enumerate_unref(enumerate);
+/* msleep(): Sleep for the requested number of milliseconds. */
+int msleep(long msec)
+{
+	struct timespec ts;
+	int res;
+
+	if (msec < 0)
+	{
+		errno = EINVAL;
+		return -1;
+	}
+
+	ts.tv_sec = msec / 1000;
+	ts.tv_nsec = (msec % 1000) * 1000000;
+
+	do {
+		res = nanosleep(&ts, &ts);
+	} while (res && errno == EINTR);
+
+	return res;
 }
 
-void MonitorDevices(struct udev* udev)
+void MonitorDevices(struct udev* udev, const char* subsystem)
 {
-    struct udev_monitor* mon = udev_monitor_new_from_netlink(udev, "udev");
+	struct udev_monitor* mon = udev_monitor_new_from_netlink(udev, "udev");
 
-    udev_monitor_filter_add_match_subsystem_devtype(mon, "usb", NULL);
-    udev_monitor_enable_receiving(mon);
+	udev_monitor_filter_add_match_subsystem_devtype(mon, subsystem, NULL);
+	udev_monitor_enable_receiving(mon);
 
-    int fd = udev_monitor_get_fd(mon);
+	int fd = udev_monitor_get_fd(mon);
 
-    while (1)
-    {
-        fd_set fds;
-        FD_ZERO(&fds);
-        FD_SET(fd, &fds);
+	while (1)
+	{
+		fd_set fds;
+		FD_ZERO(&fds);
+		FD_SET(fd, &fds);
 
-        int ret = select(fd+1, &fds, NULL, NULL, NULL);
+		int ret = select(fd + 1, &fds, NULL, NULL, NULL);
 
-        if (ret <= 0)
-        {
-            break;
-        }
+		if (ret <= 0)
+		{
+			msleep(100);
+			continue;
+		}
 
-        if (FD_ISSET(fd, &fds))
-        {
-            struct udev_device* dev = udev_monitor_receive_device(mon);
+		if (FD_ISSET(fd, &fds))
+		{
+			struct udev_device* dev = udev_monitor_receive_device(mon);
 
-            ProcessDevice(udev, dev);
-        }
-    }
+			ProcessDevice(udev, dev);
+		}
+	}
 }
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-    void StartLinuxWatcher(UsbDeviceCallback insertedCallback, UsbDeviceCallback removedCallback)
-    {
-        InsertedCallback = insertedCallback;
-        RemovedCallback = removedCallback;
+	void StartLinuxWatcher(UsbDeviceCallback insertedCallback, UsbDeviceCallback removedCallback, const char* subsystem)
+	{
+		InsertedCallback = insertedCallback;
+		RemovedCallback = removedCallback;
 
-        g_udev = udev_new();
+		g_udev = udev_new();
 
-        if (!g_udev)
-        {
-            fprintf(stderr, "udev_new() failed\n");
-            return;
-        }
+		if (!g_udev)
+		{
+			fprintf(stderr, "udev_new() failed\n");
+			return;
+		}
 
-        EnumerateDevices(g_udev);
-        MonitorDevices(g_udev);
+		EnumerateDevices(g_udev, subsystem);
+		MonitorDevices(g_udev, subsystem);
 
-        udev_unref(g_udev);
-    }
+		udev_unref(g_udev);
+	}
 
-    void GetLinuxMountPoint(const char* syspath, MountPointCallback mountPointCallback)
-    {
-        int found = 0;
+	void GetLinuxMountPoint(const char* syspath, MountPointCallback mountPointCallback)
+	{
+		int found = 0;
 
-        struct udev_device* dev = udev_device_new_from_syspath(g_udev, syspath);
+		struct udev_device* dev = udev_device_new_from_syspath(g_udev, syspath);
 
-        struct udev_device* scsi = GetChild(g_udev, dev, "scsi", NULL);
-        if (scsi)
-        {
-            struct udev_device* block = GetChild(g_udev, scsi, "block", "partition");
-            if (block)
-            {
-                const char* block_devnode = udev_device_get_devnode(block);
-                if (block_devnode)
-                {
-                    char* mount_point = FindMountPoint(block_devnode);
-                    if (mount_point)
-                    {
-                        found = 1;
-                        mountPointCallback(mount_point);
-                    }
-                }
+		if (dev)
+		{
+			struct udev_device* scsi = GetChild(g_udev, dev, "scsi", NULL);
+			if (scsi)
+			{
+				struct udev_device* block = GetChild(g_udev, scsi, "block", "partition");
+				if (block)
+				{
+					const char* block_devnode = udev_device_get_devnode(block);
+					if (block_devnode)
+					{
+						char* mount_point = FindMountPoint(block_devnode);
+						if (mount_point)
+						{
+							found = 1;
+							mountPointCallback(mount_point);
+						}
+					}
 
-                udev_device_unref(block);
-            }
+					udev_device_unref(block);
+				}
 
-            udev_device_unref(scsi);
-        }
+				udev_device_unref(scsi);
+			}
 
-        if (!found)
-            mountPointCallback("");
-    }
+			udev_device_unref(dev);
+		}
+
+		if (!found)
+			mountPointCallback("");
+	}
 
 #ifdef __cplusplus
-}
+	}
 #endif

--- a/Usb.Events/UsbEventWatcher.Linux.c
+++ b/Usb.Events/UsbEventWatcher.Linux.c
@@ -8,15 +8,15 @@
 
 typedef struct UsbDeviceData
 {
-	char DeviceName[255];
-	char DeviceSystemPath[255];
-	char Product[255];
-	char ProductDescription[255];
-	char ProductID[255];
-	char SerialNumber[255];
-	char Vendor[255];
-	char VendorDescription[255];
-	char VendorID[255];
+    char DeviceName[255];
+    char DeviceSystemPath[255];
+    char Product[255];
+    char ProductDescription[255];
+    char ProductID[255];
+    char SerialNumber[255];
+    char Vendor[255];
+    char VendorDescription[255];
+    char VendorID[255];
 } UsbDeviceData;
 
 UsbDeviceData usbDevice;
@@ -33,280 +33,280 @@ struct udev* g_udev;
 
 struct udev_device* GetChild(struct udev* udev, struct udev_device* parent, const char* subsystem, const char* devtype)
 {
-	struct udev_device* child = NULL;
-	struct udev_enumerate* enumerate = udev_enumerate_new(udev);
+    struct udev_device* child = NULL;
+    struct udev_enumerate* enumerate = udev_enumerate_new(udev);
 
-	udev_enumerate_add_match_parent(enumerate, parent);
-	udev_enumerate_add_match_subsystem(enumerate, subsystem);
-	udev_enumerate_scan_devices(enumerate);
+    udev_enumerate_add_match_parent(enumerate, parent);
+    udev_enumerate_add_match_subsystem(enumerate, subsystem);
+    udev_enumerate_scan_devices(enumerate);
 
-	for (struct udev_list_entry* entry = udev_enumerate_get_list_entry(enumerate);
-		entry != NULL;
-		entry = udev_list_entry_get_next(entry))
-	{
-		const char* path = udev_list_entry_get_name(entry);
-		child = udev_device_new_from_syspath(udev, path);
+    for (struct udev_list_entry* entry = udev_enumerate_get_list_entry(enumerate);
+        entry != NULL;
+        entry = udev_list_entry_get_next(entry))
+    {
+        const char* path = udev_list_entry_get_name(entry);
+        child = udev_device_new_from_syspath(udev, path);
 
-		if (child)
-		{
-			if ((!devtype)
-				|| (strcmp(udev_device_get_devtype(child), devtype) == 0))
-			{
-				break;
-			}
-		}
-	}
+        if (child)
+        {
+            if ((!devtype)
+                || (strcmp(udev_device_get_devtype(child), devtype) == 0))
+            {
+                break;
+            }
+        }
+    }
 
-	udev_enumerate_unref(enumerate);
+    udev_enumerate_unref(enumerate);
 
-	return child;
+    return child;
 }
 
 char* FindMountPoint(const char* dev_node)
 {
-	struct mntent* mount_table_entry;
-	FILE* file;
-	char* mount_point = NULL;
+    struct mntent* mount_table_entry;
+    FILE* file;
+    char* mount_point = NULL;
 
-	if (dev_node == NULL)
-	{
-		return NULL;
-	}
+    if (dev_node == NULL)
+    {
+        return NULL;
+    }
 
-	file = setmntent("/proc/mounts", "r");
+    file = setmntent("/proc/mounts", "r");
 
-	if (file == NULL)
-	{
-		return NULL;
-	}
+    if (file == NULL)
+    {
+        return NULL;
+    }
 
-	while (NULL != (mount_table_entry = getmntent(file)))
-	{
-		if (strncmp(mount_table_entry->mnt_fsname, dev_node, strlen(mount_table_entry->mnt_fsname)) == 0)
-		{
-			mount_point = mount_table_entry->mnt_dir;
+    while (NULL != (mount_table_entry = getmntent(file)))
+    {
+        if (strncmp(mount_table_entry->mnt_fsname, dev_node, strlen(mount_table_entry->mnt_fsname)) == 0)
+        {
+            mount_point = mount_table_entry->mnt_dir;
 
-			break;
-		}
-	}
+            break;
+        }
+    }
 
-	endmntent(file);
+    endmntent(file);
 
-	return mount_point;
+    return mount_point;
 }
 
 void GetDeviceInfo(struct udev* udev, struct udev_device* dev)
 {
-	const char* action = udev_device_get_action(dev);
-	bool added = true;
+    const char* action = udev_device_get_action(dev);
+    bool added = true;
 
-	if (action)
-	{
-		added = (strcmp(action, "remove") != 0);
-	}
+    if (action)
+    {
+        added = (strcmp(action, "remove") != 0);
+    }
 
-	usbDevice = empty;
+    usbDevice = empty;
 
-	const char* DeviceName = udev_device_get_property_value(dev, "DEVNAME");
-	if (DeviceName)
-		strcpy(usbDevice.DeviceName, DeviceName);
+    const char* DeviceName = udev_device_get_property_value(dev, "DEVNAME");
+    if (DeviceName)
+        strcpy(usbDevice.DeviceName, DeviceName);
 
-	const char* DeviceSystemPath = udev_device_get_syspath(dev); //udev_device_get_property_value(dev, "DEVPATH");
-	if (DeviceSystemPath)
-		strcpy(usbDevice.DeviceSystemPath, DeviceSystemPath);
+    const char* DeviceSystemPath = udev_device_get_syspath(dev); //udev_device_get_property_value(dev, "DEVPATH");
+    if (DeviceSystemPath)
+        strcpy(usbDevice.DeviceSystemPath, DeviceSystemPath);
 
-	const char* Product = udev_device_get_property_value(dev, "ID_MODEL");
-	if (Product)
-		strcpy(usbDevice.Product, Product);
+    const char* Product = udev_device_get_property_value(dev, "ID_MODEL");
+    if (Product)
+        strcpy(usbDevice.Product, Product);
 
-	const char* ProductDescription = udev_device_get_property_value(dev, "ID_MODEL_FROM_DATABASE");
-	if (ProductDescription)
-		strcpy(usbDevice.ProductDescription, ProductDescription);
+    const char* ProductDescription = udev_device_get_property_value(dev, "ID_MODEL_FROM_DATABASE");
+    if (ProductDescription)
+        strcpy(usbDevice.ProductDescription, ProductDescription);
 
-	const char* ProductID = udev_device_get_property_value(dev, "ID_MODEL_ID");
-	if (ProductID)
-		strcpy(usbDevice.ProductID, ProductID);
+    const char* ProductID = udev_device_get_property_value(dev, "ID_MODEL_ID");
+    if (ProductID)
+        strcpy(usbDevice.ProductID, ProductID);
 
-	const char* SerialNumber = udev_device_get_property_value(dev, "ID_SERIAL_SHORT");
-	if (SerialNumber)
-		strcpy(usbDevice.SerialNumber, SerialNumber);
+    const char* SerialNumber = udev_device_get_property_value(dev, "ID_SERIAL_SHORT");
+    if (SerialNumber)
+        strcpy(usbDevice.SerialNumber, SerialNumber);
 
-	const char* Vendor = udev_device_get_property_value(dev, "ID_VENDOR");
-	if (Vendor)
-		strcpy(usbDevice.Vendor, Vendor);
+    const char* Vendor = udev_device_get_property_value(dev, "ID_VENDOR");
+    if (Vendor)
+        strcpy(usbDevice.Vendor, Vendor);
 
-	const char* VendorDescription = udev_device_get_property_value(dev, "ID_VENDOR_FROM_DATABASE");
-	if (VendorDescription)
-		strcpy(usbDevice.VendorDescription, VendorDescription);
+    const char* VendorDescription = udev_device_get_property_value(dev, "ID_VENDOR_FROM_DATABASE");
+    if (VendorDescription)
+        strcpy(usbDevice.VendorDescription, VendorDescription);
 
-	const char* VendorID = udev_device_get_property_value(dev, "ID_VENDOR_ID");
-	if (VendorID)
-		strcpy(usbDevice.VendorID, VendorID);
+    const char* VendorID = udev_device_get_property_value(dev, "ID_VENDOR_ID");
+    if (VendorID)
+        strcpy(usbDevice.VendorID, VendorID);
 
-	if (added)
-	{
-		InsertedCallback(usbDevice);
-	}
-	else
-	{
-		RemovedCallback(usbDevice);
-	}
+    if (added)
+    {
+        InsertedCallback(usbDevice);
+    }
+    else
+    {
+        RemovedCallback(usbDevice);
+    }
 }
 
 void ProcessDevice(struct udev* udev, struct udev_device* dev)
 {
-	if (dev)
-	{
-		if (udev_device_get_devnode(dev))
-		{
-			GetDeviceInfo(udev, dev);
-		}
+    if (dev)
+    {
+        if (udev_device_get_devnode(dev))
+        {
+            GetDeviceInfo(udev, dev);
+        }
 
-		udev_device_unref(dev);
-	}
+        udev_device_unref(dev);
+    }
 }
 
 void EnumerateDevices(struct udev* udev, const char* subsystem)
 {
-	struct udev_enumerate* enumerate = udev_enumerate_new(udev);
+    struct udev_enumerate* enumerate = udev_enumerate_new(udev);
 
-	udev_enumerate_add_match_subsystem(enumerate, subsystem);
-	udev_enumerate_scan_devices(enumerate);
+    udev_enumerate_add_match_subsystem(enumerate, subsystem);
+    udev_enumerate_scan_devices(enumerate);
 
-	for (struct udev_list_entry* entry = udev_enumerate_get_list_entry(enumerate);
-		entry != NULL;
-		entry = udev_list_entry_get_next(entry))
-	{
-		const char* path = udev_list_entry_get_name(entry);
-		if (path)
-		{
-			struct udev_device* dev = udev_device_new_from_syspath(udev, path);
+    for (struct udev_list_entry* entry = udev_enumerate_get_list_entry(enumerate);
+        entry != NULL;
+        entry = udev_list_entry_get_next(entry))
+    {
+        const char* path = udev_list_entry_get_name(entry);
+        if (path)
+        {
+            struct udev_device* dev = udev_device_new_from_syspath(udev, path);
 
-			if (dev)
-			{
-				ProcessDevice(udev, dev);
-			}
-		}
-	}
+            if (dev)
+            {
+                ProcessDevice(udev, dev);
+            }
+        }
+    }
 
-	udev_enumerate_unref(enumerate);
+    udev_enumerate_unref(enumerate);
 }  
 
 /* msleep(): Sleep for the requested number of milliseconds. */
 int msleep(long msec)
 {
-	struct timespec ts;
-	int res;
+    struct timespec ts;
+    int res;
 
-	if (msec < 0)
-	{
-		errno = EINVAL;
-		return -1;
-	}
+    if (msec < 0)
+    {
+        errno = EINVAL;
+        return -1;
+    }
 
-	ts.tv_sec = msec / 1000;
-	ts.tv_nsec = (msec % 1000) * 1000000;
+    ts.tv_sec = msec / 1000;
+    ts.tv_nsec = (msec % 1000) * 1000000;
 
-	do {
-		res = nanosleep(&ts, &ts);
-	} while (res && errno == EINTR);
+    do {
+        res = nanosleep(&ts, &ts);
+    } while (res && errno == EINTR);
 
-	return res;
+    return res;
 }
 
 void MonitorDevices(struct udev* udev, const char* subsystem)
 {
-	struct udev_monitor* mon = udev_monitor_new_from_netlink(udev, "udev");
+    struct udev_monitor* mon = udev_monitor_new_from_netlink(udev, "udev");
 
-	udev_monitor_filter_add_match_subsystem_devtype(mon, subsystem, NULL);
-	udev_monitor_enable_receiving(mon);
+    udev_monitor_filter_add_match_subsystem_devtype(mon, subsystem, NULL);
+    udev_monitor_enable_receiving(mon);
 
-	int fd = udev_monitor_get_fd(mon);
+    int fd = udev_monitor_get_fd(mon);
 
-	while (1)
-	{
-		fd_set fds;
-		FD_ZERO(&fds);
-		FD_SET(fd, &fds);
+    while (1)
+    {
+        fd_set fds;
+        FD_ZERO(&fds);
+        FD_SET(fd, &fds);
 
-		int ret = select(fd + 1, &fds, NULL, NULL, NULL);
+        int ret = select(fd + 1, &fds, NULL, NULL, NULL);
 
-		if (ret <= 0)
-		{
-			msleep(100);
-			continue;
-		}
+        if (ret <= 0)
+        {
+            msleep(100);
+            continue;
+        }
 
-		if (FD_ISSET(fd, &fds))
-		{
-			struct udev_device* dev = udev_monitor_receive_device(mon);
+        if (FD_ISSET(fd, &fds))
+        {
+            struct udev_device* dev = udev_monitor_receive_device(mon);
 
-			ProcessDevice(udev, dev);
-		}
-	}
+            ProcessDevice(udev, dev);
+        }
+    }
 }
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-	void StartLinuxWatcher(UsbDeviceCallback insertedCallback, UsbDeviceCallback removedCallback, const char* subsystem)
-	{
-		InsertedCallback = insertedCallback;
-		RemovedCallback = removedCallback;
+    void StartLinuxWatcher(UsbDeviceCallback insertedCallback, UsbDeviceCallback removedCallback, const char* subsystem)
+    {
+        InsertedCallback = insertedCallback;
+        RemovedCallback = removedCallback;
 
-		g_udev = udev_new();
+        g_udev = udev_new();
 
-		if (!g_udev)
-		{
-			fprintf(stderr, "udev_new() failed\n");
-			return;
-		}
+        if (!g_udev)
+        {
+            fprintf(stderr, "udev_new() failed\n");
+            return;
+        }
 
-		EnumerateDevices(g_udev, subsystem);
-		MonitorDevices(g_udev, subsystem);
+        EnumerateDevices(g_udev, subsystem);
+        MonitorDevices(g_udev, subsystem);
 
-		udev_unref(g_udev);
-	}
+        udev_unref(g_udev);
+    }
 
-	void GetLinuxMountPoint(const char* syspath, MountPointCallback mountPointCallback)
-	{
-		int found = 0;
+    void GetLinuxMountPoint(const char* syspath, MountPointCallback mountPointCallback)
+    {
+        int found = 0;
 
-		struct udev_device* dev = udev_device_new_from_syspath(g_udev, syspath);
+        struct udev_device* dev = udev_device_new_from_syspath(g_udev, syspath);
 
-		if (dev)
-		{
-			struct udev_device* scsi = GetChild(g_udev, dev, "scsi", NULL);
-			if (scsi)
-			{
-				struct udev_device* block = GetChild(g_udev, scsi, "block", "partition");
-				if (block)
-				{
-					const char* block_devnode = udev_device_get_devnode(block);
-					if (block_devnode)
-					{
-						char* mount_point = FindMountPoint(block_devnode);
-						if (mount_point)
-						{
-							found = 1;
-							mountPointCallback(mount_point);
-						}
-					}
+        if (dev)
+        {
+            struct udev_device* scsi = GetChild(g_udev, dev, "scsi", NULL);
+            if (scsi)
+            {
+                struct udev_device* block = GetChild(g_udev, scsi, "block", "partition");
+                if (block)
+                {
+                    const char* block_devnode = udev_device_get_devnode(block);
+                    if (block_devnode)
+                    {
+                        char* mount_point = FindMountPoint(block_devnode);
+                        if (mount_point)
+                        {
+                            found = 1;
+                            mountPointCallback(mount_point);
+                        }
+                    }
 
-					udev_device_unref(block);
-				}
+                    udev_device_unref(block);
+                }
 
-				udev_device_unref(scsi);
-			}
+                udev_device_unref(scsi);
+            }
 
-			udev_device_unref(dev);
-		}
+            udev_device_unref(dev);
+        }
 
-		if (!found)
-			mountPointCallback("");
-	}
+        if (!found)
+            mountPointCallback("");
+    }
 
 #ifdef __cplusplus
-	}
+    }
 #endif

--- a/Usb.Events/UsbEventWatcher.cs
+++ b/Usb.Events/UsbEventWatcher.cs
@@ -35,14 +35,14 @@ namespace Usb.Events
 
         private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
 
-		public UsbEventWatcher(string subsystem = "usb")
+        public UsbEventWatcher(string subsystem = "usb")
         {
-			Start(subsystem);
-		}
+            Start(subsystem);
+        }
 
         #region Methods
 
-		private void Start(string subsystem)
+        private void Start(string subsystem)
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -67,7 +67,7 @@ namespace Usb.Events
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-				Task.Run(() => StartLinuxWatcher(InsertedCallback, RemovedCallback, subsystem));
+                Task.Run(() => StartLinuxWatcher(InsertedCallback, RemovedCallback, subsystem));
 
                 Task.Run(async () => 
                 {
@@ -78,7 +78,7 @@ namespace Usb.Events
                             GetLinuxMountPoint(usbDevice.DeviceSystemPath, mountPoint => SetMountPoint(usbDevice, mountPoint));
                         }
 
-						await Task.Delay(1000);
+                        await Task.Delay(1000);
                     }
                 }, _cancellationTokenSource.Token);
             }

--- a/Usb.Events/UsbEventWatcher.cs
+++ b/Usb.Events/UsbEventWatcher.cs
@@ -9,417 +9,417 @@ using System.Threading.Tasks;
 
 namespace Usb.Events
 {
-    public class UsbEventWatcher : IUsbEventWatcher, IDisposable
-    {
-        #region IUsbEventWatcher
+	public class UsbEventWatcher : IUsbEventWatcher, IDisposable
+	{
+		#region IUsbEventWatcher
 
-        public List<string> UsbDrivePathList { get; private set; } = new List<string>();
-        public List<UsbDevice> UsbDeviceList { get; private set; } = new List<UsbDevice>();
+		public List<string> UsbDrivePathList { get; private set; } = new List<string>();
+		public List<UsbDevice> UsbDeviceList { get; private set; } = new List<UsbDevice>();
 
-        public event EventHandler<string>? UsbDriveMounted;
+		public event EventHandler<string>? UsbDriveMounted;
 
-        public event EventHandler<string>? UsbDriveEjected;
+		public event EventHandler<string>? UsbDriveEjected;
 
-        public event EventHandler<UsbDevice>? UsbDeviceAdded;
+		public event EventHandler<UsbDevice>? UsbDeviceAdded;
 
-        public event EventHandler<UsbDevice>? UsbDeviceRemoved;
+		public event EventHandler<UsbDevice>? UsbDeviceRemoved;
 
-        #endregion IUsbEventWatcher
+		#endregion IUsbEventWatcher
 
-        #region Windows fields
+		#region Windows fields
 
-        private ManagementEventWatcher _volumeChangeEventWatcher = null!;
+		private ManagementEventWatcher _volumeChangeEventWatcher = null!;
 
-        private ManagementEventWatcher _USBControllerDeviceCreationEventWatcher = null!;
-        private ManagementEventWatcher _USBControllerDeviceDeletionEventWatcher = null!;
+		private ManagementEventWatcher _USBControllerDeviceCreationEventWatcher = null!;
+		private ManagementEventWatcher _USBControllerDeviceDeletionEventWatcher = null!;
 
-        #endregion Windows fields
+		#endregion Windows fields
 
-        private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
+		private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
 
-        public UsbEventWatcher(string subsystem = "usb")
-        {
-            Start(subsystem);
-        }
+		public UsbEventWatcher(string subsystem = "usb")
+		{
+			Start(subsystem);
+		}
 
-        #region Methods
+		#region Methods
 
-        private void Start(string subsystem)
-        {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                StartWindowsWatcher();
-            }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                Task.Run(() => StartMacWatcher(InsertedCallback, RemovedCallback));
+		private void Start(string subsystem)
+		{
+			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+			{
+				StartWindowsWatcher();
+			}
+			else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+			{
+				Task.Run(() => StartMacWatcher(InsertedCallback, RemovedCallback));
 
-                Task.Run(async () =>
-                {
-                    while (!_cancellationTokenSource.Token.IsCancellationRequested)
-                    {
-                        foreach (UsbDevice usbDevice in UsbDeviceList.Where(device => !string.IsNullOrEmpty(device.DeviceSystemPath)))
-                        {
-                            GetMacMountPoint(usbDevice.DeviceSystemPath, mountPoint => SetMountPoint(usbDevice, mountPoint));
-                        }
+				Task.Run(async () =>
+				{
+					while (!_cancellationTokenSource.Token.IsCancellationRequested)
+					{
+						foreach (UsbDevice usbDevice in UsbDeviceList.Where(device => !string.IsNullOrEmpty(device.DeviceSystemPath)))
+						{
+							GetMacMountPoint(usbDevice.DeviceSystemPath, mountPoint => SetMountPoint(usbDevice, mountPoint));
+						}
 
-                        await Task.Delay(1000);
-                    }
-                }, _cancellationTokenSource.Token);
-            }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                Task.Run(() => StartLinuxWatcher(InsertedCallback, RemovedCallback, subsystem));
+						await Task.Delay(1000);
+					}
+				}, _cancellationTokenSource.Token);
+			}
+			else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+			{
+				Task.Run(() => StartLinuxWatcher(InsertedCallback, RemovedCallback, subsystem));
 
-                Task.Run(async () =>
-                {
-                    while (!_cancellationTokenSource.Token.IsCancellationRequested)
-                    {
-                        foreach (UsbDevice usbDevice in UsbDeviceList.Where(device => !string.IsNullOrEmpty(device.DeviceSystemPath)))
-                        {
-                            GetLinuxMountPoint(usbDevice.DeviceSystemPath, mountPoint => SetMountPoint(usbDevice, mountPoint));
-                        }
+				Task.Run(async () =>
+				{
+					while (!_cancellationTokenSource.Token.IsCancellationRequested)
+					{
+						foreach (UsbDevice usbDevice in UsbDeviceList.Where(device => !string.IsNullOrEmpty(device.DeviceSystemPath)))
+						{
+							GetLinuxMountPoint(usbDevice.DeviceSystemPath, mountPoint => SetMountPoint(usbDevice, mountPoint));
+						}
 
-                        await Task.Delay(1000);
-                    }
-                }, _cancellationTokenSource.Token);
-            }
-        }
+						await Task.Delay(1000);
+					}
+				}, _cancellationTokenSource.Token);
+			}
+		}
 
-        private void SetMountPoint(UsbDevice usbDevice, string mountPoint)
-        {
-            if (string.IsNullOrEmpty(usbDevice.MountedDirectoryPath) && !string.IsNullOrEmpty(mountPoint))
-            {
-                usbDevice.MountedDirectoryPath = mountPoint;
-                OnDriveInserted(usbDevice.MountedDirectoryPath);
+		private void SetMountPoint(UsbDevice usbDevice, string mountPoint)
+		{
+			if (string.IsNullOrEmpty(usbDevice.MountedDirectoryPath) && !string.IsNullOrEmpty(mountPoint))
+			{
+				usbDevice.MountedDirectoryPath = mountPoint;
+				OnDriveInserted(usbDevice.MountedDirectoryPath);
 
-                usbDevice.IsEjected = false;
-                usbDevice.IsMounted = true;
-            }
-            else if (!string.IsNullOrEmpty(usbDevice.MountedDirectoryPath) && string.IsNullOrEmpty(mountPoint))
-            {
-                OnDriveRemoved(usbDevice.MountedDirectoryPath);
-                usbDevice.MountedDirectoryPath = mountPoint;
+				usbDevice.IsEjected = false;
+				usbDevice.IsMounted = true;
+			}
+			else if (!string.IsNullOrEmpty(usbDevice.MountedDirectoryPath) && string.IsNullOrEmpty(mountPoint))
+			{
+				OnDriveRemoved(usbDevice.MountedDirectoryPath);
+				usbDevice.MountedDirectoryPath = mountPoint;
 
-                usbDevice.IsEjected = true;
-                usbDevice.IsMounted = false;
-            }
-        }
+				usbDevice.IsEjected = true;
+				usbDevice.IsMounted = false;
+			}
+		}
 
-        private void OnDriveInserted(string path)
-        {
-            UsbDriveMounted?.Invoke(this, path);
-            UsbDrivePathList.Add(path);
-        }
+		private void OnDriveInserted(string path)
+		{
+			UsbDriveMounted?.Invoke(this, path);
+			UsbDrivePathList.Add(path);
+		}
 
-        private void OnDriveRemoved(string path)
-        {
-            UsbDriveEjected?.Invoke(this, path);
-            UsbDrivePathList.RemoveAll(p => p == path);
-        }
+		private void OnDriveRemoved(string path)
+		{
+			UsbDriveEjected?.Invoke(this, path);
+			UsbDrivePathList.RemoveAll(p => p == path);
+		}
 
-        private void OnDeviceInserted(UsbDevice usbDevice)
-        {
-            UsbDeviceAdded?.Invoke(this, usbDevice);
-            UsbDeviceList.Add(usbDevice);
-        }
+		private void OnDeviceInserted(UsbDevice usbDevice)
+		{
+			UsbDeviceAdded?.Invoke(this, usbDevice);
+			UsbDeviceList.Add(usbDevice);
+		}
 
-        private void OnDeviceRemoved(UsbDevice usbDevice)
-        {
-            UsbDeviceRemoved?.Invoke(this, usbDevice);
+		private void OnDeviceRemoved(UsbDevice usbDevice)
+		{
+			UsbDeviceRemoved?.Invoke(this, usbDevice);
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                UsbDeviceList.RemoveAll(device => device.DeviceName == usbDevice.DeviceName && device.DeviceSystemPath == usbDevice.DeviceSystemPath);
-            }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                UsbDeviceList.RemoveAll(device => device.ProductID == usbDevice.ProductID && device.VendorID == usbDevice.VendorID && device.SerialNumber == usbDevice.SerialNumber);
-            }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                UsbDeviceList.RemoveAll(device => device.SerialNumber == usbDevice.SerialNumber);
-            }
-        }
+			if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+			{
+				UsbDeviceList.RemoveAll(device => device.DeviceName == usbDevice.DeviceName && device.DeviceSystemPath == usbDevice.DeviceSystemPath);
+			}
+			else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+			{
+				UsbDeviceList.RemoveAll(device => device.ProductID == usbDevice.ProductID && device.VendorID == usbDevice.VendorID && device.SerialNumber == usbDevice.SerialNumber);
+			}
+			else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+			{
+				UsbDeviceList.RemoveAll(device => device.SerialNumber == usbDevice.SerialNumber);
+			}
+		}
 
-        #endregion Methods
+		#endregion Methods
 
-        #region Linux and Mac methods
+		#region Linux and Mac methods
 
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Auto)]
-        private delegate void UsbDeviceCallback(UsbDeviceData usbDevice);
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Auto)]
+		private delegate void UsbDeviceCallback(UsbDeviceData usbDevice);
 
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Auto)]
-        private delegate void MountPointCallback(string mountPoint);
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Auto)]
+		private delegate void MountPointCallback(string mountPoint);
 
-        private void InsertedCallback(UsbDeviceData usbDevice)
-        {
-            OnDeviceInserted(new UsbDevice(usbDevice));
-        }
+		private void InsertedCallback(UsbDeviceData usbDevice)
+		{
+			OnDeviceInserted(new UsbDevice(usbDevice));
+		}
 
-        private void RemovedCallback(UsbDeviceData usbDevice)
-        {
-            OnDeviceRemoved(new UsbDevice(usbDevice));
-        }
+		private void RemovedCallback(UsbDeviceData usbDevice)
+		{
+			OnDeviceRemoved(new UsbDevice(usbDevice));
+		}
 
-        [DllImport("UsbEventWatcher.Linux.so", CallingConvention = CallingConvention.Cdecl)]
-        private static extern void GetLinuxMountPoint(string syspath, MountPointCallback mountPointCallback);
+		[DllImport("UsbEventWatcher.Linux.so", CallingConvention = CallingConvention.Cdecl)]
+		private static extern void GetLinuxMountPoint(string syspath, MountPointCallback mountPointCallback);
 
-        [DllImport("UsbEventWatcher.Linux.so", CallingConvention = CallingConvention.Cdecl)]
-        private static extern void StartLinuxWatcher(UsbDeviceCallback insertedCallback, UsbDeviceCallback removedCallback, string subsystem);
+		[DllImport("UsbEventWatcher.Linux.so", CallingConvention = CallingConvention.Cdecl)]
+		private static extern void StartLinuxWatcher(UsbDeviceCallback insertedCallback, UsbDeviceCallback removedCallback, string subsystem);
 
-        [DllImport("UsbEventWatcher.Mac.dylib", CallingConvention = CallingConvention.Cdecl)]
-        private static extern void GetMacMountPoint(string syspath, MountPointCallback mountPointCallback);
+		[DllImport("UsbEventWatcher.Mac.dylib", CallingConvention = CallingConvention.Cdecl)]
+		private static extern void GetMacMountPoint(string syspath, MountPointCallback mountPointCallback);
 
-        [DllImport("UsbEventWatcher.Mac.dylib", CallingConvention = CallingConvention.Cdecl)]
-        private static extern void StartMacWatcher(UsbDeviceCallback insertedCallback, UsbDeviceCallback removedCallback);
+		[DllImport("UsbEventWatcher.Mac.dylib", CallingConvention = CallingConvention.Cdecl)]
+		private static extern void StartMacWatcher(UsbDeviceCallback insertedCallback, UsbDeviceCallback removedCallback);
 
-        #endregion Linux and Mac methods
+		#endregion Linux and Mac methods
 
-        #region Windows methods
+		#region Windows methods
 
-        private void StartWindowsWatcher()
-        {
-            UsbDrivePathList = new List<string>(DriveInfo.GetDrives()
-                .Where(driveInfo => driveInfo.DriveType == DriveType.Removable && driveInfo.IsReady)
-                .Select(driveInfo => driveInfo.Name.TrimEnd(Path.DirectorySeparatorChar)));
+		private void StartWindowsWatcher()
+		{
+			UsbDrivePathList = new List<string>(DriveInfo.GetDrives()
+				.Where(driveInfo => driveInfo.DriveType == DriveType.Removable && driveInfo.IsReady)
+				.Select(driveInfo => driveInfo.Name.TrimEnd(Path.DirectorySeparatorChar)));
 
-            _volumeChangeEventWatcher = new ManagementEventWatcher();
-            _volumeChangeEventWatcher.EventArrived += new EventArrivedEventHandler(VolumeChangeEventWatcher_EventArrived);
-            _volumeChangeEventWatcher.Query = new WqlEventQuery("SELECT * FROM Win32_VolumeChangeEvent WHERE EventType = 2 or EventType = 3");
-            _volumeChangeEventWatcher.Start();
+			_volumeChangeEventWatcher = new ManagementEventWatcher();
+			_volumeChangeEventWatcher.EventArrived += new EventArrivedEventHandler(VolumeChangeEventWatcher_EventArrived);
+			_volumeChangeEventWatcher.Query = new WqlEventQuery("SELECT * FROM Win32_VolumeChangeEvent WHERE EventType = 2 or EventType = 3");
+			_volumeChangeEventWatcher.Start();
 
-            _USBControllerDeviceCreationEventWatcher = new ManagementEventWatcher();
-            _USBControllerDeviceCreationEventWatcher.EventArrived += new EventArrivedEventHandler(USBControllerDeviceCreationEventWatcher_EventArrived);
-            _USBControllerDeviceCreationEventWatcher.Query = new WqlEventQuery("SELECT * FROM __InstanceCreationEvent WITHIN 2 WHERE TargetInstance ISA 'Win32_USBControllerDevice'");
-            _USBControllerDeviceCreationEventWatcher.Start();
+			_USBControllerDeviceCreationEventWatcher = new ManagementEventWatcher();
+			_USBControllerDeviceCreationEventWatcher.EventArrived += new EventArrivedEventHandler(USBControllerDeviceCreationEventWatcher_EventArrived);
+			_USBControllerDeviceCreationEventWatcher.Query = new WqlEventQuery("SELECT * FROM __InstanceCreationEvent WITHIN 2 WHERE TargetInstance ISA 'Win32_USBControllerDevice'");
+			_USBControllerDeviceCreationEventWatcher.Start();
 
-            _USBControllerDeviceDeletionEventWatcher = new ManagementEventWatcher();
-            _USBControllerDeviceDeletionEventWatcher.EventArrived += new EventArrivedEventHandler(USBControllerDeviceDeletionEventWatcher_EventArrived);
-            _USBControllerDeviceDeletionEventWatcher.Query = new WqlEventQuery("SELECT * FROM __InstanceDeletionEvent WITHIN 2 WHERE TargetInstance ISA 'Win32_USBControllerDevice'");
-            _USBControllerDeviceDeletionEventWatcher.Start();
-        }
+			_USBControllerDeviceDeletionEventWatcher = new ManagementEventWatcher();
+			_USBControllerDeviceDeletionEventWatcher.EventArrived += new EventArrivedEventHandler(USBControllerDeviceDeletionEventWatcher_EventArrived);
+			_USBControllerDeviceDeletionEventWatcher.Query = new WqlEventQuery("SELECT * FROM __InstanceDeletionEvent WITHIN 2 WHERE TargetInstance ISA 'Win32_USBControllerDevice'");
+			_USBControllerDeviceDeletionEventWatcher.Start();
+		}
 
-        private void VolumeChangeEventWatcher_EventArrived(object sender, EventArrivedEventArgs e)
-        {
-            ManagementBaseObject Win32_VolumeChangeEvent = e.NewEvent;
+		private void VolumeChangeEventWatcher_EventArrived(object sender, EventArrivedEventArgs e)
+		{
+			ManagementBaseObject Win32_VolumeChangeEvent = e.NewEvent;
 
-            string driveName = Win32_VolumeChangeEvent["DriveName"].ToString();
-            string eventType = Win32_VolumeChangeEvent["EventType"].ToString();
+			string driveName = Win32_VolumeChangeEvent["DriveName"].ToString();
+			string eventType = Win32_VolumeChangeEvent["EventType"].ToString();
 
-            bool inserted = eventType == "2";
-            bool removed = eventType == "3";
+			bool inserted = eventType == "2";
+			bool removed = eventType == "3";
 
-            if (inserted)
-            {
-                foreach (UsbDevice usbDevice in UsbDeviceList.Where(device => device.MountedDirectoryPath == driveName))
-                {
-                    usbDevice.IsEjected = false;
-                    usbDevice.IsMounted = true;
-                }
+			if (inserted)
+			{
+				foreach (UsbDevice usbDevice in UsbDeviceList.Where(device => device.MountedDirectoryPath == driveName))
+				{
+					usbDevice.IsEjected = false;
+					usbDevice.IsMounted = true;
+				}
 
-                OnDriveInserted(driveName);
-            }
+				OnDriveInserted(driveName);
+			}
 
-            if (removed)
-            {
-                foreach (UsbDevice usbDevice in UsbDeviceList.Where(device => device.MountedDirectoryPath == driveName))
-                {
-                    usbDevice.IsEjected = true;
-                    usbDevice.IsMounted = false;
-                }
+			if (removed)
+			{
+				foreach (UsbDevice usbDevice in UsbDeviceList.Where(device => device.MountedDirectoryPath == driveName))
+				{
+					usbDevice.IsEjected = true;
+					usbDevice.IsMounted = false;
+				}
 
-                OnDriveRemoved(driveName);
-            }
-        }
+				OnDriveRemoved(driveName);
+			}
+		}
 
-        private static void DebugOutput(ManagementBaseObject managementBaseObject)
-        {
+		private static void DebugOutput(ManagementBaseObject managementBaseObject)
+		{
 #if DEBUG
-            System.Diagnostics.Debug.WriteLine(string.Empty);
+			System.Diagnostics.Debug.WriteLine(string.Empty);
 
-            foreach (PropertyData property in managementBaseObject.Properties)
-            {
-                System.Diagnostics.Debug.WriteLine(property.Name + " = " + property.Value);
-            }
+			foreach (PropertyData property in managementBaseObject.Properties)
+			{
+				System.Diagnostics.Debug.WriteLine(property.Name + " = " + property.Value);
+			}
 
-            System.Diagnostics.Debug.WriteLine(string.Empty);
+			System.Diagnostics.Debug.WriteLine(string.Empty);
 #endif
-        }
+		}
 
-        private void USBControllerDeviceCreationEventWatcher_EventArrived(object sender, EventArrivedEventArgs e)
-        {
-            ManagementBaseObject Win32_USBControllerDevice = (ManagementBaseObject)e.NewEvent["TargetInstance"];
+		private void USBControllerDeviceCreationEventWatcher_EventArrived(object sender, EventArrivedEventArgs e)
+		{
+			ManagementBaseObject Win32_USBControllerDevice = (ManagementBaseObject)e.NewEvent["TargetInstance"];
 
-            string deviceID = GetUSBControllerDeviceID(Win32_USBControllerDevice);
+			string deviceID = GetUSBControllerDeviceID(Win32_USBControllerDevice);
 
-            UsbDevice? usbDevice = GetUsbDevice(deviceID);
+			UsbDevice? usbDevice = GetUsbDevice(deviceID);
 
-            if (usbDevice != null)
-            {
-                usbDevice.IsEjected = false;
-                usbDevice.IsMounted = true;
+			if (usbDevice != null)
+			{
+				usbDevice.IsEjected = false;
+				usbDevice.IsMounted = true;
 
-                OnDeviceInserted(usbDevice);
-            }
-        }
+				OnDeviceInserted(usbDevice);
+			}
+		}
 
-        private void USBControllerDeviceDeletionEventWatcher_EventArrived(object sender, EventArrivedEventArgs e)
-        {
-            ManagementBaseObject Win32_USBControllerDevice = (ManagementBaseObject)e.NewEvent["TargetInstance"];
+		private void USBControllerDeviceDeletionEventWatcher_EventArrived(object sender, EventArrivedEventArgs e)
+		{
+			ManagementBaseObject Win32_USBControllerDevice = (ManagementBaseObject)e.NewEvent["TargetInstance"];
 
-            string deviceID = GetUSBControllerDeviceID(Win32_USBControllerDevice);
+			string deviceID = GetUSBControllerDeviceID(Win32_USBControllerDevice);
 
-            UsbDevice? usbDevice = GetUsbDevice(deviceID);
+			UsbDevice? usbDevice = GetUsbDevice(deviceID);
 
-            if (usbDevice != null)
-            {
-                usbDevice.IsEjected = true;
-                usbDevice.IsMounted = false;
+			if (usbDevice != null)
+			{
+				usbDevice.IsEjected = true;
+				usbDevice.IsMounted = false;
 
-                OnDeviceRemoved(usbDevice);
-            }
-        }
+				OnDeviceRemoved(usbDevice);
+			}
+		}
 
-        private static string GetUSBControllerDeviceID(ManagementBaseObject Win32_USBControllerDevice)
-        {
-            DebugOutput(Win32_USBControllerDevice);
+		private static string GetUSBControllerDeviceID(ManagementBaseObject Win32_USBControllerDevice)
+		{
+			DebugOutput(Win32_USBControllerDevice);
 
-            string dependent = Win32_USBControllerDevice["Dependent"].ToString();
-            string[] dependentInfo = dependent.Split('"');
+			string dependent = Win32_USBControllerDevice["Dependent"].ToString();
+			string[] dependentInfo = dependent.Split('"');
 
-            if (dependentInfo.Length < 2)
-                return string.Empty;
+			if (dependentInfo.Length < 2)
+				return string.Empty;
 
-            return dependentInfo[1].Replace(@"\\", @"\");
-        }
+			return dependentInfo[1].Replace(@"\\", @"\");
+		}
 
-        private static UsbDevice? GetUsbDevice(string deviceID)
-        {
-            string[] deviceInfo = deviceID.Split('\\');
+		private static UsbDevice? GetUsbDevice(string deviceID)
+		{
+			string[] deviceInfo = deviceID.Split('\\');
 
-            if (deviceInfo.Length < 3)
-                return null;
+			if (deviceInfo.Length < 3)
+				return null;
 
-            string[] id = deviceInfo[1].Split('&');
+			string[] id = deviceInfo[1].Split('&');
 
-            if (id.Length < 2)
-                return null;
+			if (id.Length < 2)
+				return null;
 
-            if (id[0].Length != 8 || !id[0].StartsWith("VID_"))
-                return null;
+			if (id[0].Length != 8 || !id[0].StartsWith("VID_"))
+				return null;
 
-            string vendorId = id[0].Substring(4, 4);
+			string vendorId = id[0].Substring(4, 4);
 
-            if (id[1].Length != 8 || !id[1].StartsWith("PID_"))
-                return null;
+			if (id[1].Length != 8 || !id[1].StartsWith("PID_"))
+				return null;
 
-            string productId = id[1].Substring(4, 4);
+			string productId = id[1].Substring(4, 4);
 
-            string serial = deviceInfo[2];
+			string serial = deviceInfo[2];
 
-            UsbDevice usbDevice = new UsbDevice
-            {
-                DeviceSystemPath = deviceID,
-                ProductID = productId,
-                SerialNumber = serial,
-                VendorID = vendorId
-            };
+			UsbDevice usbDevice = new UsbDevice
+			{
+				DeviceSystemPath = deviceID,
+				ProductID = productId,
+				SerialNumber = serial,
+				VendorID = vendorId
+			};
 
-            string WindowsPortableDevicesClassGuid = "{eec5ad98-8080-425f-922a-dabf3de3f69a}";
+			string WindowsPortableDevicesClassGuid = "{eec5ad98-8080-425f-922a-dabf3de3f69a}";
 
 #if DEBUG
-            using ManagementObjectSearcher Win32_PnPEntity = new ManagementObjectSearcher($"SELECT * FROM Win32_PnPEntity WHERE DeviceID LIKE '%{serial}%'");
+			using ManagementObjectSearcher Win32_PnPEntity = new ManagementObjectSearcher($"SELECT * FROM Win32_PnPEntity WHERE DeviceID LIKE '%{serial}%'");
 #else
-            using ManagementObjectSearcher Win32_PnPEntity = new ManagementObjectSearcher($"SELECT Caption, ClassGuid, Description, Manufacturer FROM Win32_PnPEntity WHERE DeviceID LIKE '%{serial}%'");
+			using ManagementObjectSearcher Win32_PnPEntity = new ManagementObjectSearcher($"SELECT Caption, ClassGuid, Description, Manufacturer FROM Win32_PnPEntity WHERE DeviceID LIKE '%{serial}%'");
 #endif
 
-            foreach (ManagementObject entity in Win32_PnPEntity.Get())
-            {
-                DebugOutput(entity);
+			foreach (ManagementObject entity in Win32_PnPEntity.Get())
+			{
+				DebugOutput(entity);
 
-                usbDevice.DeviceName = entity["Caption"]?.ToString()?.Trim() ?? string.Empty;
-                usbDevice.Product = entity["Description"]?.ToString()?.Trim() ?? string.Empty;
-                usbDevice.ProductDescription = entity["Description"]?.ToString()?.Trim() ?? string.Empty;
-                usbDevice.Vendor = entity["Manufacturer"]?.ToString()?.Trim() ?? string.Empty;
-                usbDevice.VendorDescription = entity["Manufacturer"]?.ToString()?.Trim() ?? string.Empty;
+				usbDevice.DeviceName = entity["Caption"]?.ToString()?.Trim() ?? string.Empty;
+				usbDevice.Product = entity["Description"]?.ToString()?.Trim() ?? string.Empty;
+				usbDevice.ProductDescription = entity["Description"]?.ToString()?.Trim() ?? string.Empty;
+				usbDevice.Vendor = entity["Manufacturer"]?.ToString()?.Trim() ?? string.Empty;
+				usbDevice.VendorDescription = entity["Manufacturer"]?.ToString()?.Trim() ?? string.Empty;
 
-                string ClassGuid = entity["ClassGuid"]?.ToString()?.Trim() ?? string.Empty;
+				string ClassGuid = entity["ClassGuid"]?.ToString()?.Trim() ?? string.Empty;
 
-                // most USB devices have only one ManagementObject that contains Caption, Description, Manufacturer
-                // but USB flash drives have several ManagementObject-s and only WindowsPortableDevices has useful info
-                if (ClassGuid == WindowsPortableDevicesClassGuid)
-                {
-                    break;
-                }
-            }
+				// most USB devices have only one ManagementObject that contains Caption, Description, Manufacturer
+				// but USB flash drives have several ManagementObject-s and only WindowsPortableDevices has useful info
+				if (ClassGuid == WindowsPortableDevicesClassGuid)
+				{
+					break;
+				}
+			}
 
-            using ManagementObjectSearcher Win32_USBHub = new ManagementObjectSearcher($"SELECT * FROM Win32_USBHub WHERE DeviceID LIKE '%{serial}%'");
+			using ManagementObjectSearcher Win32_USBHub = new ManagementObjectSearcher($"SELECT * FROM Win32_USBHub WHERE DeviceID LIKE '%{serial}%'");
 
-            if (Win32_USBHub.Get().Count > 0)
-            {
-                int attempts = 0;
+			if (Win32_USBHub.Get().Count > 0)
+			{
+				int attempts = 0;
 
-                while (++attempts < 9000)
-                {
-                    usbDevice.MountedDirectoryPath = GetDevicePath(serial);
+				while (++attempts < 9000)
+				{
+					usbDevice.MountedDirectoryPath = GetDevicePath(serial);
 
-                    if (string.IsNullOrEmpty(usbDevice.MountedDirectoryPath))
-                    {
-                        System.Threading.Thread.Sleep(1);
-                    }
-                    else
-                    {
-                        break;
-                    }
-                }
-            }
+					if (string.IsNullOrEmpty(usbDevice.MountedDirectoryPath))
+					{
+						System.Threading.Thread.Sleep(1);
+					}
+					else
+					{
+						break;
+					}
+				}
+			}
 
-            return usbDevice;
-        }
+			return usbDevice;
+		}
 
-        private static string GetDevicePath(string serial)
-        {
-            string devicePath = string.Empty;
+		private static string GetDevicePath(string serial)
+		{
+			string devicePath = string.Empty;
 
-            using ManagementObjectSearcher Win32_DiskDrive = new ManagementObjectSearcher(
-                $"SELECT DeviceID FROM Win32_DiskDrive WHERE PNPDeviceID LIKE '%{serial}%'");
+			using ManagementObjectSearcher Win32_DiskDrive = new ManagementObjectSearcher(
+				$"SELECT DeviceID FROM Win32_DiskDrive WHERE PNPDeviceID LIKE '%{serial}%'");
 
-            foreach (ManagementObject drive in Win32_DiskDrive.Get())
-            {
-                using ManagementObjectSearcher Win32_DiskDriveToDiskPartition = new ManagementObjectSearcher(
-                    "ASSOCIATORS OF {Win32_DiskDrive.DeviceID='" + drive["DeviceID"] + "'} WHERE AssocClass = Win32_DiskDriveToDiskPartition");
+			foreach (ManagementObject drive in Win32_DiskDrive.Get())
+			{
+				using ManagementObjectSearcher Win32_DiskDriveToDiskPartition = new ManagementObjectSearcher(
+					"ASSOCIATORS OF {Win32_DiskDrive.DeviceID='" + drive["DeviceID"] + "'} WHERE AssocClass = Win32_DiskDriveToDiskPartition");
 
-                foreach (ManagementObject partition in Win32_DiskDriveToDiskPartition.Get())
-                {
-                    using ManagementObjectSearcher Win32_LogicalDiskToPartition = new ManagementObjectSearcher(
-                        "ASSOCIATORS OF {Win32_DiskPartition.DeviceID='" + partition["DeviceID"] + "'} WHERE AssocClass = Win32_LogicalDiskToPartition");
+				foreach (ManagementObject partition in Win32_DiskDriveToDiskPartition.Get())
+				{
+					using ManagementObjectSearcher Win32_LogicalDiskToPartition = new ManagementObjectSearcher(
+						"ASSOCIATORS OF {Win32_DiskPartition.DeviceID='" + partition["DeviceID"] + "'} WHERE AssocClass = Win32_LogicalDiskToPartition");
 
-                    foreach (ManagementObject disk in Win32_LogicalDiskToPartition.Get())
-                    {
-                        devicePath = disk["DeviceID"].ToString();
-                    }
-                }
-            }
+					foreach (ManagementObject disk in Win32_LogicalDiskToPartition.Get())
+					{
+						devicePath = disk["DeviceID"].ToString();
+					}
+				}
+			}
 
-            return devicePath;
-        }
+			return devicePath;
+		}
 
-        public void Dispose()
-        {
-            _cancellationTokenSource.Cancel();
-            _cancellationTokenSource.Dispose();
+		public void Dispose()
+		{
+			_cancellationTokenSource.Cancel();
+			_cancellationTokenSource.Dispose();
 
-            _volumeChangeEventWatcher.Stop();
-            _volumeChangeEventWatcher.Dispose();
+			_volumeChangeEventWatcher.Stop();
+			_volumeChangeEventWatcher.Dispose();
 
-            _USBControllerDeviceCreationEventWatcher.Stop();
-            _USBControllerDeviceCreationEventWatcher.Dispose();
+			_USBControllerDeviceCreationEventWatcher.Stop();
+			_USBControllerDeviceCreationEventWatcher.Dispose();
 
-            _USBControllerDeviceDeletionEventWatcher.Stop();
-            _USBControllerDeviceDeletionEventWatcher.Dispose();
-        }
+			_USBControllerDeviceDeletionEventWatcher.Stop();
+			_USBControllerDeviceDeletionEventWatcher.Dispose();
+		}
 
-        #endregion Windows methods
-    }
+		#endregion Windows methods
+	}
 }

--- a/Usb.Events/UsbEventWatcher.cs
+++ b/Usb.Events/UsbEventWatcher.cs
@@ -35,14 +35,14 @@ namespace Usb.Events
 
         private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
 
-        public UsbEventWatcher(string subsystem = "usb")
+        public UsbEventWatcher()
         {
-            Start(subsystem);
+            Start();
         }
 
         #region Methods
 
-        private void Start(string subsystem)
+        private void Start()
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -67,7 +67,7 @@ namespace Usb.Events
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                Task.Run(() => StartLinuxWatcher(InsertedCallback, RemovedCallback, subsystem));
+                Task.Run(() => StartLinuxWatcher(InsertedCallback, RemovedCallback));
 
                 Task.Run(async () => 
                 {

--- a/Usb.Events/UsbEventWatcher.cs
+++ b/Usb.Events/UsbEventWatcher.cs
@@ -9,417 +9,415 @@ using System.Threading.Tasks;
 
 namespace Usb.Events
 {
-	public class UsbEventWatcher : IUsbEventWatcher, IDisposable
-	{
-		#region IUsbEventWatcher
+    public class UsbEventWatcher : IUsbEventWatcher, IDisposable
+    {
+        #region IUsbEventWatcher
 
-		public List<string> UsbDrivePathList { get; private set; } = new List<string>();
-		public List<UsbDevice> UsbDeviceList { get; private set; } = new List<UsbDevice>();
+        public List<string> UsbDrivePathList { get; private set; } = new List<string>();
+        public List<UsbDevice> UsbDeviceList { get; private set; } = new List<UsbDevice>();
 
-		public event EventHandler<string>? UsbDriveMounted;
+        public event EventHandler<string>? UsbDriveMounted;
+        public event EventHandler<string>? UsbDriveEjected;
 
-		public event EventHandler<string>? UsbDriveEjected;
+        public event EventHandler<UsbDevice>? UsbDeviceAdded;
+        public event EventHandler<UsbDevice>? UsbDeviceRemoved;
 
-		public event EventHandler<UsbDevice>? UsbDeviceAdded;
+        #endregion
 
-		public event EventHandler<UsbDevice>? UsbDeviceRemoved;
+        #region Windows fields
 
-		#endregion IUsbEventWatcher
+        private ManagementEventWatcher _volumeChangeEventWatcher = null!;
 
-		#region Windows fields
+        private ManagementEventWatcher _USBControllerDeviceCreationEventWatcher = null!;
+        private ManagementEventWatcher _USBControllerDeviceDeletionEventWatcher = null!;
 
-		private ManagementEventWatcher _volumeChangeEventWatcher = null!;
+        #endregion
 
-		private ManagementEventWatcher _USBControllerDeviceCreationEventWatcher = null!;
-		private ManagementEventWatcher _USBControllerDeviceDeletionEventWatcher = null!;
-
-		#endregion Windows fields
-
-		private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
+        private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
 
 		public UsbEventWatcher(string subsystem = "usb")
-		{
+        {
 			Start(subsystem);
 		}
 
-		#region Methods
+        #region Methods
 
 		private void Start(string subsystem)
-		{
-			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-			{
-				StartWindowsWatcher();
-			}
-			else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-			{
-				Task.Run(() => StartMacWatcher(InsertedCallback, RemovedCallback));
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                StartWindowsWatcher();
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                Task.Run(() => StartMacWatcher(InsertedCallback, RemovedCallback));
 
-				Task.Run(async () =>
-				{
-					while (!_cancellationTokenSource.Token.IsCancellationRequested)
-					{
-						foreach (UsbDevice usbDevice in UsbDeviceList.Where(device => !string.IsNullOrEmpty(device.DeviceSystemPath)))
-						{
-							GetMacMountPoint(usbDevice.DeviceSystemPath, mountPoint => SetMountPoint(usbDevice, mountPoint));
-						}
+                Task.Run(async () =>
+                {
+                    while (!_cancellationTokenSource.Token.IsCancellationRequested)
+                    {
+                        foreach (UsbDevice usbDevice in UsbDeviceList.Where(device => !string.IsNullOrEmpty(device.DeviceSystemPath)))
+                        {
+                            GetMacMountPoint(usbDevice.DeviceSystemPath, mountPoint => SetMountPoint(usbDevice, mountPoint));
+                        }
 
-						await Task.Delay(1000);
-					}
-				}, _cancellationTokenSource.Token);
-			}
-			else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-			{
+                        await Task.Delay(1000);
+                    }
+                }, _cancellationTokenSource.Token);
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
 				Task.Run(() => StartLinuxWatcher(InsertedCallback, RemovedCallback, subsystem));
 
-				Task.Run(async () =>
-				{
-					while (!_cancellationTokenSource.Token.IsCancellationRequested)
-					{
-						foreach (UsbDevice usbDevice in UsbDeviceList.Where(device => !string.IsNullOrEmpty(device.DeviceSystemPath)))
-						{
-							GetLinuxMountPoint(usbDevice.DeviceSystemPath, mountPoint => SetMountPoint(usbDevice, mountPoint));
-						}
+                Task.Run(async () => 
+                {
+                    while (!_cancellationTokenSource.Token.IsCancellationRequested)
+                    {
+                        foreach (UsbDevice usbDevice in UsbDeviceList.Where(device => !string.IsNullOrEmpty(device.DeviceSystemPath)))
+                        {
+                            GetLinuxMountPoint(usbDevice.DeviceSystemPath, mountPoint => SetMountPoint(usbDevice, mountPoint));
+                        }
 
 						await Task.Delay(1000);
-					}
-				}, _cancellationTokenSource.Token);
-			}
-		}
+                    }
+                }, _cancellationTokenSource.Token);
+            }
+        }
 
-		private void SetMountPoint(UsbDevice usbDevice, string mountPoint)
-		{
-			if (string.IsNullOrEmpty(usbDevice.MountedDirectoryPath) && !string.IsNullOrEmpty(mountPoint))
-			{
-				usbDevice.MountedDirectoryPath = mountPoint;
-				OnDriveInserted(usbDevice.MountedDirectoryPath);
+        private void SetMountPoint(UsbDevice usbDevice, string mountPoint)
+        {
+            if (string.IsNullOrEmpty(usbDevice.MountedDirectoryPath) && !string.IsNullOrEmpty(mountPoint))
+            {
+                usbDevice.MountedDirectoryPath = mountPoint;
+                OnDriveInserted(usbDevice.MountedDirectoryPath);
 
-				usbDevice.IsEjected = false;
-				usbDevice.IsMounted = true;
-			}
-			else if (!string.IsNullOrEmpty(usbDevice.MountedDirectoryPath) && string.IsNullOrEmpty(mountPoint))
-			{
-				OnDriveRemoved(usbDevice.MountedDirectoryPath);
-				usbDevice.MountedDirectoryPath = mountPoint;
+                usbDevice.IsEjected = false;
+                usbDevice.IsMounted = true;
+            }
+            else if (!string.IsNullOrEmpty(usbDevice.MountedDirectoryPath) && string.IsNullOrEmpty(mountPoint))
+            {
+                OnDriveRemoved(usbDevice.MountedDirectoryPath);
+                usbDevice.MountedDirectoryPath = mountPoint;
 
-				usbDevice.IsEjected = true;
-				usbDevice.IsMounted = false;
-			}
-		}
+                usbDevice.IsEjected = true;
+                usbDevice.IsMounted = false;
+            }
+        }
 
-		private void OnDriveInserted(string path)
-		{
-			UsbDriveMounted?.Invoke(this, path);
-			UsbDrivePathList.Add(path);
-		}
+        private void OnDriveInserted(string path)
+        {
+            UsbDriveMounted?.Invoke(this, path);
+            UsbDrivePathList.Add(path);
+        }
 
-		private void OnDriveRemoved(string path)
-		{
-			UsbDriveEjected?.Invoke(this, path);
-			UsbDrivePathList.RemoveAll(p => p == path);
-		}
+        private void OnDriveRemoved(string path)
+        {
+            UsbDriveEjected?.Invoke(this, path);
+            UsbDrivePathList.RemoveAll(p => p == path);
+        }
 
-		private void OnDeviceInserted(UsbDevice usbDevice)
-		{
-			UsbDeviceAdded?.Invoke(this, usbDevice);
-			UsbDeviceList.Add(usbDevice);
-		}
+        private void OnDeviceInserted(UsbDevice usbDevice)
+        {
+            UsbDeviceAdded?.Invoke(this, usbDevice);
+            UsbDeviceList.Add(usbDevice);
+        }
 
-		private void OnDeviceRemoved(UsbDevice usbDevice)
-		{
-			UsbDeviceRemoved?.Invoke(this, usbDevice);
+        private void OnDeviceRemoved(UsbDevice usbDevice)
+        {
+            UsbDeviceRemoved?.Invoke(this, usbDevice);
 
-			if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-			{
-				UsbDeviceList.RemoveAll(device => device.DeviceName == usbDevice.DeviceName && device.DeviceSystemPath == usbDevice.DeviceSystemPath);
-			}
-			else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-			{
-				UsbDeviceList.RemoveAll(device => device.ProductID == usbDevice.ProductID && device.VendorID == usbDevice.VendorID && device.SerialNumber == usbDevice.SerialNumber);
-			}
-			else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-			{
-				UsbDeviceList.RemoveAll(device => device.SerialNumber == usbDevice.SerialNumber);
-			}
-		}
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                UsbDeviceList.RemoveAll(device => device.DeviceName == usbDevice.DeviceName && device.DeviceSystemPath == usbDevice.DeviceSystemPath);
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                UsbDeviceList.RemoveAll(device => device.ProductID == usbDevice.ProductID && device.VendorID == usbDevice.VendorID && device.SerialNumber == usbDevice.SerialNumber);
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                UsbDeviceList.RemoveAll(device => device.SerialNumber == usbDevice.SerialNumber);
+            }
+        }
 
-		#endregion Methods
+        #endregion
 
-		#region Linux and Mac methods
+        #region Linux and Mac methods
 
-		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Auto)]
-		private delegate void UsbDeviceCallback(UsbDeviceData usbDevice);
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Auto)]
+        delegate void UsbDeviceCallback(UsbDeviceData usbDevice);
 
-		[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Auto)]
-		private delegate void MountPointCallback(string mountPoint);
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Auto)]
+        delegate void MountPointCallback(string mountPoint);
 
-		private void InsertedCallback(UsbDeviceData usbDevice)
-		{
-			OnDeviceInserted(new UsbDevice(usbDevice));
-		}
+        private void InsertedCallback(UsbDeviceData usbDevice)
+        {
+            OnDeviceInserted(new UsbDevice(usbDevice));
+        }
 
-		private void RemovedCallback(UsbDeviceData usbDevice)
-		{
-			OnDeviceRemoved(new UsbDevice(usbDevice));
-		}
+        private void RemovedCallback(UsbDeviceData usbDevice)
+        {
+            OnDeviceRemoved(new UsbDevice(usbDevice));
+        }
 
-		[DllImport("UsbEventWatcher.Linux.so", CallingConvention = CallingConvention.Cdecl)]
-		private static extern void GetLinuxMountPoint(string syspath, MountPointCallback mountPointCallback);
+        [DllImport("UsbEventWatcher.Linux.so", CallingConvention = CallingConvention.Cdecl)]
+        static extern void GetLinuxMountPoint(string syspath, MountPointCallback mountPointCallback);
 
-		[DllImport("UsbEventWatcher.Linux.so", CallingConvention = CallingConvention.Cdecl)]
-		private static extern void StartLinuxWatcher(UsbDeviceCallback insertedCallback, UsbDeviceCallback removedCallback, string subsystem);
+        [DllImport("UsbEventWatcher.Linux.so", CallingConvention = CallingConvention.Cdecl)]
+        static extern void StartLinuxWatcher(UsbDeviceCallback insertedCallback, UsbDeviceCallback removedCallback);
 
-		[DllImport("UsbEventWatcher.Mac.dylib", CallingConvention = CallingConvention.Cdecl)]
-		private static extern void GetMacMountPoint(string syspath, MountPointCallback mountPointCallback);
+        [DllImport("UsbEventWatcher.Mac.dylib", CallingConvention = CallingConvention.Cdecl)]
+        static extern void GetMacMountPoint(string syspath, MountPointCallback mountPointCallback);
 
-		[DllImport("UsbEventWatcher.Mac.dylib", CallingConvention = CallingConvention.Cdecl)]
-		private static extern void StartMacWatcher(UsbDeviceCallback insertedCallback, UsbDeviceCallback removedCallback);
+        [DllImport("UsbEventWatcher.Mac.dylib", CallingConvention = CallingConvention.Cdecl)]
+        static extern void StartMacWatcher(UsbDeviceCallback insertedCallback, UsbDeviceCallback removedCallback);
 
-		#endregion Linux and Mac methods
+        #endregion
 
-		#region Windows methods
+        #region Windows methods
 
-		private void StartWindowsWatcher()
-		{
-			UsbDrivePathList = new List<string>(DriveInfo.GetDrives()
-				.Where(driveInfo => driveInfo.DriveType == DriveType.Removable && driveInfo.IsReady)
-				.Select(driveInfo => driveInfo.Name.TrimEnd(Path.DirectorySeparatorChar)));
+        private void StartWindowsWatcher()
+        {
+            UsbDrivePathList = new List<string>(DriveInfo.GetDrives()
+                .Where(driveInfo => driveInfo.DriveType == DriveType.Removable && driveInfo.IsReady)
+                .Select(driveInfo => driveInfo.Name.TrimEnd(Path.DirectorySeparatorChar)));
 
-			_volumeChangeEventWatcher = new ManagementEventWatcher();
-			_volumeChangeEventWatcher.EventArrived += new EventArrivedEventHandler(VolumeChangeEventWatcher_EventArrived);
-			_volumeChangeEventWatcher.Query = new WqlEventQuery("SELECT * FROM Win32_VolumeChangeEvent WHERE EventType = 2 or EventType = 3");
-			_volumeChangeEventWatcher.Start();
+            _volumeChangeEventWatcher = new ManagementEventWatcher();
+            _volumeChangeEventWatcher.EventArrived += new EventArrivedEventHandler(VolumeChangeEventWatcher_EventArrived);
+            _volumeChangeEventWatcher.Query = new WqlEventQuery("SELECT * FROM Win32_VolumeChangeEvent WHERE EventType = 2 or EventType = 3");
+            _volumeChangeEventWatcher.Start();
 
-			_USBControllerDeviceCreationEventWatcher = new ManagementEventWatcher();
-			_USBControllerDeviceCreationEventWatcher.EventArrived += new EventArrivedEventHandler(USBControllerDeviceCreationEventWatcher_EventArrived);
-			_USBControllerDeviceCreationEventWatcher.Query = new WqlEventQuery("SELECT * FROM __InstanceCreationEvent WITHIN 2 WHERE TargetInstance ISA 'Win32_USBControllerDevice'");
-			_USBControllerDeviceCreationEventWatcher.Start();
+            _USBControllerDeviceCreationEventWatcher = new ManagementEventWatcher();
+            _USBControllerDeviceCreationEventWatcher.EventArrived += new EventArrivedEventHandler(USBControllerDeviceCreationEventWatcher_EventArrived);
+            _USBControllerDeviceCreationEventWatcher.Query = new WqlEventQuery("SELECT * FROM __InstanceCreationEvent WITHIN 2 WHERE TargetInstance ISA 'Win32_USBControllerDevice'");
+            _USBControllerDeviceCreationEventWatcher.Start();
 
-			_USBControllerDeviceDeletionEventWatcher = new ManagementEventWatcher();
-			_USBControllerDeviceDeletionEventWatcher.EventArrived += new EventArrivedEventHandler(USBControllerDeviceDeletionEventWatcher_EventArrived);
-			_USBControllerDeviceDeletionEventWatcher.Query = new WqlEventQuery("SELECT * FROM __InstanceDeletionEvent WITHIN 2 WHERE TargetInstance ISA 'Win32_USBControllerDevice'");
-			_USBControllerDeviceDeletionEventWatcher.Start();
-		}
+            _USBControllerDeviceDeletionEventWatcher = new ManagementEventWatcher();
+            _USBControllerDeviceDeletionEventWatcher.EventArrived += new EventArrivedEventHandler(USBControllerDeviceDeletionEventWatcher_EventArrived);
+            _USBControllerDeviceDeletionEventWatcher.Query = new WqlEventQuery("SELECT * FROM __InstanceDeletionEvent WITHIN 2 WHERE TargetInstance ISA 'Win32_USBControllerDevice'");
+            _USBControllerDeviceDeletionEventWatcher.Start();
+        }
 
-		private void VolumeChangeEventWatcher_EventArrived(object sender, EventArrivedEventArgs e)
-		{
-			ManagementBaseObject Win32_VolumeChangeEvent = e.NewEvent;
+        private void VolumeChangeEventWatcher_EventArrived(object sender, EventArrivedEventArgs e)
+        {
+            ManagementBaseObject Win32_VolumeChangeEvent = e.NewEvent;
 
-			string driveName = Win32_VolumeChangeEvent["DriveName"].ToString();
-			string eventType = Win32_VolumeChangeEvent["EventType"].ToString();
+            string driveName = Win32_VolumeChangeEvent["DriveName"].ToString();
+            string eventType = Win32_VolumeChangeEvent["EventType"].ToString();
 
-			bool inserted = eventType == "2";
-			bool removed = eventType == "3";
+            bool inserted = eventType == "2";
+            bool removed = eventType == "3";
 
-			if (inserted)
-			{
-				foreach (UsbDevice usbDevice in UsbDeviceList.Where(device => device.MountedDirectoryPath == driveName))
-				{
-					usbDevice.IsEjected = false;
-					usbDevice.IsMounted = true;
-				}
+            if (inserted)
+            {
+                foreach (UsbDevice usbDevice in UsbDeviceList.Where(device => device.MountedDirectoryPath == driveName))
+                {
+                    usbDevice.IsEjected = false;
+                    usbDevice.IsMounted = true;
+                }
 
-				OnDriveInserted(driveName);
-			}
+                OnDriveInserted(driveName);
+            }
 
-			if (removed)
-			{
-				foreach (UsbDevice usbDevice in UsbDeviceList.Where(device => device.MountedDirectoryPath == driveName))
-				{
-					usbDevice.IsEjected = true;
-					usbDevice.IsMounted = false;
-				}
+            if (removed)
+            {
+                foreach (UsbDevice usbDevice in UsbDeviceList.Where(device => device.MountedDirectoryPath == driveName))
+                {
+                    usbDevice.IsEjected = true;
+                    usbDevice.IsMounted = false;
+                }
 
-				OnDriveRemoved(driveName);
-			}
-		}
+                OnDriveRemoved(driveName);
+            }
+        }
 
-		private static void DebugOutput(ManagementBaseObject managementBaseObject)
-		{
+        private static void DebugOutput(ManagementBaseObject managementBaseObject)
+        {
 #if DEBUG
-			System.Diagnostics.Debug.WriteLine(string.Empty);
+            System.Diagnostics.Debug.WriteLine(string.Empty);
 
-			foreach (PropertyData property in managementBaseObject.Properties)
-			{
-				System.Diagnostics.Debug.WriteLine(property.Name + " = " + property.Value);
-			}
+            foreach (PropertyData property in managementBaseObject.Properties)
+            {
+                System.Diagnostics.Debug.WriteLine(property.Name + " = " + property.Value);
+            }
 
-			System.Diagnostics.Debug.WriteLine(string.Empty);
+            System.Diagnostics.Debug.WriteLine(string.Empty);
 #endif
-		}
+        }
 
-		private void USBControllerDeviceCreationEventWatcher_EventArrived(object sender, EventArrivedEventArgs e)
-		{
-			ManagementBaseObject Win32_USBControllerDevice = (ManagementBaseObject)e.NewEvent["TargetInstance"];
+        private void USBControllerDeviceCreationEventWatcher_EventArrived(object sender, EventArrivedEventArgs e)
+        {
+            ManagementBaseObject Win32_USBControllerDevice = (ManagementBaseObject)e.NewEvent["TargetInstance"];
 
-			string deviceID = GetUSBControllerDeviceID(Win32_USBControllerDevice);
+            string deviceID = GetUSBControllerDeviceID(Win32_USBControllerDevice);
 
-			UsbDevice? usbDevice = GetUsbDevice(deviceID);
+            UsbDevice? usbDevice = GetUsbDevice(deviceID);
 
-			if (usbDevice != null)
-			{
-				usbDevice.IsEjected = false;
-				usbDevice.IsMounted = true;
+            if (usbDevice != null)
+            {
+                usbDevice.IsEjected = false;
+                usbDevice.IsMounted = true;
 
-				OnDeviceInserted(usbDevice);
-			}
-		}
+                OnDeviceInserted(usbDevice);
+            }
+        }
 
-		private void USBControllerDeviceDeletionEventWatcher_EventArrived(object sender, EventArrivedEventArgs e)
-		{
-			ManagementBaseObject Win32_USBControllerDevice = (ManagementBaseObject)e.NewEvent["TargetInstance"];
+        private void USBControllerDeviceDeletionEventWatcher_EventArrived(object sender, EventArrivedEventArgs e)
+        {
+            ManagementBaseObject Win32_USBControllerDevice = (ManagementBaseObject)e.NewEvent["TargetInstance"];
 
-			string deviceID = GetUSBControllerDeviceID(Win32_USBControllerDevice);
+            string deviceID = GetUSBControllerDeviceID(Win32_USBControllerDevice);
 
-			UsbDevice? usbDevice = GetUsbDevice(deviceID);
+            UsbDevice? usbDevice = GetUsbDevice(deviceID);
 
-			if (usbDevice != null)
-			{
-				usbDevice.IsEjected = true;
-				usbDevice.IsMounted = false;
+            if (usbDevice != null)
+            {
+                usbDevice.IsEjected = true;
+                usbDevice.IsMounted = false;
 
-				OnDeviceRemoved(usbDevice);
-			}
-		}
+                OnDeviceRemoved(usbDevice);
+            }
+        }
 
-		private static string GetUSBControllerDeviceID(ManagementBaseObject Win32_USBControllerDevice)
-		{
-			DebugOutput(Win32_USBControllerDevice);
+        private static string GetUSBControllerDeviceID(ManagementBaseObject Win32_USBControllerDevice)
+        {
+            DebugOutput(Win32_USBControllerDevice);
 
-			string dependent = Win32_USBControllerDevice["Dependent"].ToString();
-			string[] dependentInfo = dependent.Split('"');
+            string dependent = Win32_USBControllerDevice["Dependent"].ToString();
+            string[] dependentInfo = dependent.Split('"');
 
-			if (dependentInfo.Length < 2)
-				return string.Empty;
+            if (dependentInfo.Length < 2)
+                return string.Empty;
 
-			return dependentInfo[1].Replace(@"\\", @"\");
-		}
+            return dependentInfo[1].Replace(@"\\", @"\");
+        }
 
-		private static UsbDevice? GetUsbDevice(string deviceID)
-		{
-			string[] deviceInfo = deviceID.Split('\\');
+        private static UsbDevice? GetUsbDevice(string deviceID)
+        {
+            string[] deviceInfo = deviceID.Split('\\');
 
-			if (deviceInfo.Length < 3)
-				return null;
+            if (deviceInfo.Length < 3)
+                return null;
 
-			string[] id = deviceInfo[1].Split('&');
+            string[] id = deviceInfo[1].Split('&');
 
-			if (id.Length < 2)
-				return null;
+            if (id.Length < 2)
+                return null;
 
-			if (id[0].Length != 8 || !id[0].StartsWith("VID_"))
-				return null;
+            if (id[0].Length != 8 || !id[0].StartsWith("VID_"))
+                return null;
 
-			string vendorId = id[0].Substring(4, 4);
+            string vendorId = id[0].Substring(4, 4);
 
-			if (id[1].Length != 8 || !id[1].StartsWith("PID_"))
-				return null;
+            if (id[1].Length != 8 || !id[1].StartsWith("PID_"))
+                return null;
 
-			string productId = id[1].Substring(4, 4);
+            string productId = id[1].Substring(4, 4);
 
-			string serial = deviceInfo[2];
+            string serial = deviceInfo[2];
 
-			UsbDevice usbDevice = new UsbDevice
-			{
-				DeviceSystemPath = deviceID,
-				ProductID = productId,
-				SerialNumber = serial,
-				VendorID = vendorId
-			};
+            UsbDevice usbDevice = new UsbDevice
+            {
+                DeviceSystemPath = deviceID,
+                ProductID = productId,
+                SerialNumber = serial,
+                VendorID = vendorId
+            };
 
-			string WindowsPortableDevicesClassGuid = "{eec5ad98-8080-425f-922a-dabf3de3f69a}";
+            string WindowsPortableDevicesClassGuid = "{eec5ad98-8080-425f-922a-dabf3de3f69a}";
 
 #if DEBUG
-			using ManagementObjectSearcher Win32_PnPEntity = new ManagementObjectSearcher($"SELECT * FROM Win32_PnPEntity WHERE DeviceID LIKE '%{serial}%'");
+            using ManagementObjectSearcher Win32_PnPEntity = new ManagementObjectSearcher($"SELECT * FROM Win32_PnPEntity WHERE DeviceID LIKE '%{serial}%'");
 #else
-			using ManagementObjectSearcher Win32_PnPEntity = new ManagementObjectSearcher($"SELECT Caption, ClassGuid, Description, Manufacturer FROM Win32_PnPEntity WHERE DeviceID LIKE '%{serial}%'");
+            using ManagementObjectSearcher Win32_PnPEntity = new ManagementObjectSearcher($"SELECT Caption, ClassGuid, Description, Manufacturer FROM Win32_PnPEntity WHERE DeviceID LIKE '%{serial}%'");
 #endif
 
-			foreach (ManagementObject entity in Win32_PnPEntity.Get())
-			{
-				DebugOutput(entity);
+            foreach (ManagementObject entity in Win32_PnPEntity.Get())
+            {
+                DebugOutput(entity);
 
-				usbDevice.DeviceName = entity["Caption"]?.ToString()?.Trim() ?? string.Empty;
-				usbDevice.Product = entity["Description"]?.ToString()?.Trim() ?? string.Empty;
-				usbDevice.ProductDescription = entity["Description"]?.ToString()?.Trim() ?? string.Empty;
-				usbDevice.Vendor = entity["Manufacturer"]?.ToString()?.Trim() ?? string.Empty;
-				usbDevice.VendorDescription = entity["Manufacturer"]?.ToString()?.Trim() ?? string.Empty;
+                usbDevice.DeviceName = entity["Caption"]?.ToString()?.Trim() ?? string.Empty;
+                usbDevice.Product = entity["Description"]?.ToString()?.Trim() ?? string.Empty;
+                usbDevice.ProductDescription = entity["Description"]?.ToString()?.Trim() ?? string.Empty;
+                usbDevice.Vendor = entity["Manufacturer"]?.ToString()?.Trim() ?? string.Empty;
+                usbDevice.VendorDescription = entity["Manufacturer"]?.ToString()?.Trim() ?? string.Empty;
 
-				string ClassGuid = entity["ClassGuid"]?.ToString()?.Trim() ?? string.Empty;
+                string ClassGuid = entity["ClassGuid"]?.ToString()?.Trim() ?? string.Empty;
 
-				// most USB devices have only one ManagementObject that contains Caption, Description, Manufacturer
-				// but USB flash drives have several ManagementObject-s and only WindowsPortableDevices has useful info
-				if (ClassGuid == WindowsPortableDevicesClassGuid)
-				{
-					break;
-				}
-			}
+                // most USB devices have only one ManagementObject that contains Caption, Description, Manufacturer
+                // but USB flash drives have several ManagementObject-s and only WindowsPortableDevices has useful info
+                if (ClassGuid == WindowsPortableDevicesClassGuid)
+                {
+                    break;
+                }
+            }
 
-			using ManagementObjectSearcher Win32_USBHub = new ManagementObjectSearcher($"SELECT * FROM Win32_USBHub WHERE DeviceID LIKE '%{serial}%'");
+            using ManagementObjectSearcher Win32_USBHub = new ManagementObjectSearcher($"SELECT * FROM Win32_USBHub WHERE DeviceID LIKE '%{serial}%'");
 
-			if (Win32_USBHub.Get().Count > 0)
-			{
-				int attempts = 0;
+            if (Win32_USBHub.Get().Count > 0)
+            {
+                int attempts = 0;
 
-				while (++attempts < 9000)
-				{
-					usbDevice.MountedDirectoryPath = GetDevicePath(serial);
+                while (++attempts < 9000)
+                {
+                    usbDevice.MountedDirectoryPath = GetDevicePath(serial);
 
-					if (string.IsNullOrEmpty(usbDevice.MountedDirectoryPath))
-					{
-						System.Threading.Thread.Sleep(1);
-					}
-					else
-					{
-						break;
-					}
-				}
-			}
+                    if (string.IsNullOrEmpty(usbDevice.MountedDirectoryPath))
+                    {
+                        System.Threading.Thread.Sleep(1);
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+            }
 
-			return usbDevice;
-		}
+            return usbDevice;
+        }
 
-		private static string GetDevicePath(string serial)
-		{
-			string devicePath = string.Empty;
+        private static string GetDevicePath(string serial)
+        {
+            string devicePath = string.Empty;
 
-			using ManagementObjectSearcher Win32_DiskDrive = new ManagementObjectSearcher(
-				$"SELECT DeviceID FROM Win32_DiskDrive WHERE PNPDeviceID LIKE '%{serial}%'");
+            using ManagementObjectSearcher Win32_DiskDrive = new ManagementObjectSearcher(
+                $"SELECT DeviceID FROM Win32_DiskDrive WHERE PNPDeviceID LIKE '%{serial}%'");
 
-			foreach (ManagementObject drive in Win32_DiskDrive.Get())
-			{
-				using ManagementObjectSearcher Win32_DiskDriveToDiskPartition = new ManagementObjectSearcher(
-					"ASSOCIATORS OF {Win32_DiskDrive.DeviceID='" + drive["DeviceID"] + "'} WHERE AssocClass = Win32_DiskDriveToDiskPartition");
+            foreach (ManagementObject drive in Win32_DiskDrive.Get())
+            {
+                using ManagementObjectSearcher Win32_DiskDriveToDiskPartition = new ManagementObjectSearcher(
+                    "ASSOCIATORS OF {Win32_DiskDrive.DeviceID='" + drive["DeviceID"] + "'} WHERE AssocClass = Win32_DiskDriveToDiskPartition");
 
-				foreach (ManagementObject partition in Win32_DiskDriveToDiskPartition.Get())
-				{
-					using ManagementObjectSearcher Win32_LogicalDiskToPartition = new ManagementObjectSearcher(
-						"ASSOCIATORS OF {Win32_DiskPartition.DeviceID='" + partition["DeviceID"] + "'} WHERE AssocClass = Win32_LogicalDiskToPartition");
+                foreach (ManagementObject partition in Win32_DiskDriveToDiskPartition.Get())
+                {
+                    using ManagementObjectSearcher Win32_LogicalDiskToPartition = new ManagementObjectSearcher(
+                        "ASSOCIATORS OF {Win32_DiskPartition.DeviceID='" + partition["DeviceID"] + "'} WHERE AssocClass = Win32_LogicalDiskToPartition");
 
-					foreach (ManagementObject disk in Win32_LogicalDiskToPartition.Get())
-					{
-						devicePath = disk["DeviceID"].ToString();
-					}
-				}
-			}
+                    foreach (ManagementObject disk in Win32_LogicalDiskToPartition.Get())
+                    {
+                        devicePath = disk["DeviceID"].ToString();
+                    }
+                }
+            }
 
-			return devicePath;
-		}
+            return devicePath;
+        }
 
-		public void Dispose()
-		{
-			_cancellationTokenSource.Cancel();
-			_cancellationTokenSource.Dispose();
+        public void Dispose()
+        {
+            _cancellationTokenSource.Cancel();
+            _cancellationTokenSource.Dispose();
 
-			_volumeChangeEventWatcher.Stop();
-			_volumeChangeEventWatcher.Dispose();
+            _volumeChangeEventWatcher.Stop();
+            _volumeChangeEventWatcher.Dispose();
 
-			_USBControllerDeviceCreationEventWatcher.Stop();
-			_USBControllerDeviceCreationEventWatcher.Dispose();
+            _USBControllerDeviceCreationEventWatcher.Stop();
+            _USBControllerDeviceCreationEventWatcher.Dispose();
 
-			_USBControllerDeviceDeletionEventWatcher.Stop();
-			_USBControllerDeviceDeletionEventWatcher.Dispose();
-		}
+            _USBControllerDeviceDeletionEventWatcher.Stop();
+            _USBControllerDeviceDeletionEventWatcher.Dispose();
+        }
 
-		#endregion Windows methods
-	}
+        #endregion
+    }
 }


### PR DESCRIPTION
This PR addresses the following issues plus increases the poll time for mass storage devices under Linux from 100 milliseconds to one second to reduce CPU usage.

https://github.com/Jinjinov/Usb.Events/issues/6
https://github.com/Jinjinov/Usb.Events/issues/7
https://github.com/Jinjinov/Usb.Events/issues/8
https://github.com/Jinjinov/Usb.Events/issues/9