### PR TITLE
Catch InvalidOperationException in mountpoint task to prevent crash i…

### DIFF
--- a/Usb.Events/UsbEventWatcher.cs
+++ b/Usb.Events/UsbEventWatcher.cs
@@ -81,9 +81,17 @@ namespace Usb.Events
                 {
                     while (!_cancellationTokenSource.Token.IsCancellationRequested)
                     {
-                        foreach (UsbDevice usbDevice in UsbDeviceList.Where(device => !string.IsNullOrEmpty(device.DeviceSystemPath)))
+                        try
                         {
-                            GetMacMountPoint(usbDevice.DeviceSystemPath, mountPoint => SetMountPoint(usbDevice, mountPoint));
+                            foreach (UsbDevice usbDevice in UsbDeviceList.Where(device => !string.IsNullOrEmpty(device.DeviceSystemPath)))
+                            {
+                                GetMacMountPoint(usbDevice.DeviceSystemPath, mountPoint => SetMountPoint(usbDevice, mountPoint));
+                            }
+                        }
+                        catch (InvalidOperationException)
+                        {
+                            // Prevent application crash and ignore possible exception when collection was changed because this may
+                            // happen by another thread or task
                         }
 
                         await Task.Delay(1000, _cancellationTokenSource.Token);
@@ -100,9 +108,17 @@ namespace Usb.Events
                 {
                     while (!_cancellationTokenSource.Token.IsCancellationRequested)
                     {
-                        foreach (UsbDevice usbDevice in UsbDeviceList.Where(device => !string.IsNullOrEmpty(device.DeviceSystemPath)))
+                        try
                         {
-                            GetLinuxMountPoint(usbDevice.DeviceSystemPath, mountPoint => SetMountPoint(usbDevice, mountPoint));
+                            foreach (UsbDevice usbDevice in UsbDeviceList.Where(device => !string.IsNullOrEmpty(device.DeviceSystemPath)))
+                            {
+                                GetLinuxMountPoint(usbDevice.DeviceSystemPath, mountPoint => SetMountPoint(usbDevice, mountPoint));
+                            }
+                        }
+                        catch (InvalidOperationException)
+                        {
+                            // Prevent application crash and ignore possible exception when collection was changed because this may
+                            // happen by another thread or task
                         }
 
                         await Task.Delay(1000, _cancellationTokenSource.Token);

--- a/Usb.Events/UsbEventWatcher.cs
+++ b/Usb.Events/UsbEventWatcher.cs
@@ -83,7 +83,7 @@ namespace Usb.Events
                     {
                         try
                         {
-                            foreach (UsbDevice usbDevice in UsbDeviceList.Where(device => !string.IsNullOrEmpty(device.DeviceSystemPath)))
+                            foreach (UsbDevice usbDevice in UsbDeviceList.ToList().Where(device => !string.IsNullOrEmpty(device.DeviceSystemPath)))
                             {
                                 GetMacMountPoint(usbDevice.DeviceSystemPath, mountPoint => SetMountPoint(usbDevice, mountPoint));
                             }
@@ -110,7 +110,7 @@ namespace Usb.Events
                     {
                         try
                         {
-                            foreach (UsbDevice usbDevice in UsbDeviceList.Where(device => !string.IsNullOrEmpty(device.DeviceSystemPath)))
+                            foreach (UsbDevice usbDevice in UsbDeviceList.ToList().Where(device => !string.IsNullOrEmpty(device.DeviceSystemPath)))
                             {
                                 GetLinuxMountPoint(usbDevice.DeviceSystemPath, mountPoint => SetMountPoint(usbDevice, mountPoint));
                             }


### PR DESCRIPTION
Hello Jinjinov,
Thank you for this nice library.
Someone has reported to me that a Linux machine has had an application crash because in a task triggered by the class UsbEventWatcher. There was an uncatched InvalidOperatioException.
I think that the exception was raised in the mountpoint task used by Linux when the collection UsbDeviceList was changed during the enumeration in the loop because it's not allowed to change a collection during the foreach iterations.
This may happen due to other parts.
Instead of locking all access to the UsbDeviceList command I decide to catch this exception and try again the access in the next loop. Due to this the change has a low impact and the code is easier to read compared to the lock statements. Also the impact for Windows is 0.
If you has any questions, let me know.
Best regards,
Frank
