### PR TITLE
fix build issue with xcode 15.0.1

### DIFF
--- a/Usb.Events/Mac/UsbEventWatcher.Mac.h
+++ b/Usb.Events/Mac/UsbEventWatcher.Mac.h
@@ -30,7 +30,7 @@ void GetMacMountPoint(const char* syspath, MountPointCallback mountPointCallback
 
 void StartMacWatcher(UsbDeviceCallback insertedCallback, UsbDeviceCallback removedCallback);
 
-void StopMacWatcher();
+void StopMacWatcher(void);
 
 #ifdef __cplusplus
 }

--- a/Usb.Events/Mac/main.c
+++ b/Usb.Events/Mac/main.c
@@ -19,7 +19,7 @@ void *StartWatcher(void *arg)
     pthread_exit(NULL);
 }
 
-int main()
+int main(void)
 {
     pthread_t thread;
 


### PR DESCRIPTION
Little fix.
I tried to build the UsbEventWatcher.Mac.dylib on my mac and got an error said that a function declaration without a prototype is deprecated in all versions of C.
so I added some void prototypes for function declaration.