### PR TITLE
Add parameter (isUseMountPoint) to activate/deactivate the mount/eject events

### DIFF
--- a/Usb.Events/IUsbEventWatcher.cs
+++ b/Usb.Events/IUsbEventWatcher.cs
@@ -44,6 +44,7 @@ namespace Usb.Events
         /// <param name="addAlreadyPresentDevicesToList">Set addAlreadyPresentDevicesToList to true to include already present devices in UsbDeviceList</param>
         /// <param name="usePnPEntity">Set usePnPEntity to true to query Win32_PnPEntity instead of Win32_USBControllerDevice in Windows</param>
         /// <param name="includeTTY">Set includeTTY to true to monitor the TTY subsystem in Linux (besides the USB subsystem)</param>
-        void Start(bool addAlreadyPresentDevicesToList = false, bool usePnPEntity = false, bool includeTTY = false);
+        /// <param name="isUseMountPoint">Activate/Deactivate mount point with <see cref="UsbDriveMounted"/> and <see cref="UsbDriveEjected"/></param>
+        void Start(bool addAlreadyPresentDevicesToList = false, bool usePnPEntity = false, bool includeTTY = false, bool isUseMountPoint = true);
     }
 }


### PR DESCRIPTION
In some cases the mount operation(s) (`_mountPointTask`) are not needed and would cause more performance as needed. I added a new parameter to deactivate the `_mointPointTask` for Linux and OSX.