### PR TITLE
Fix UsbDriveMounted/Ejected for drives without a partition table

### DIFF
--- a/Usb.Events/Linux/UsbEventWatcher.Linux.c
+++ b/Usb.Events/Linux/UsbEventWatcher.Linux.c
@@ -449,6 +449,10 @@ extern "C" {
                 if (scsi)
                 {
                     struct udev_device* block = GetChild(g_udev, scsi, "block", "partition");
+		    if (!block)
+		    {
+		        block = GetChild(g_udev, scsi, "block", "disk");
+		    }
                     if (block)
                     {
                         const char* block_devnode = udev_device_get_devnode(block);


### PR DESCRIPTION
We recently came across a USB drive which, even though it was mounted just fine, would not generate an UsbDeviceMounted event. After some debugging, I found that the device did not have a partition table. Instead, the filesystem had been created directly on the block device. While I don't think that's common, it works perfectly well. On Windows, it's also hard to change since Windows will not automatically create a partition table if you format the device.
The problem with devices like this is that GetLinuxMountPoint specifically looks for a udev device with the type "partition", which doesn't exist if there are no partitions. To fix this, I propose to check for a device of type "disk" in case no partitions are found. With this fix, events are generated as they should be, and partitions take precedence if they exist, so this shouldn't break anything.